### PR TITLE
[PREVIEW] TESTING - Load appliationInsights before everything else

### DIFF
--- a/server.js
+++ b/server.js
@@ -1,12 +1,10 @@
+require('./services/app-insights')();
 const logger = require('@hmcts/nodejs-logging').Logger.getLogger(__filename);
 const app = require('./app');
 const config = require('config');
 const path = require('path');
 const https = require('https');
 const fs = require('fs');
-const appInsights = require('./services/app-insights');
-
-appInsights();
 
 let http = {};
 


### PR DESCRIPTION
# Description

Previous node was failing to close even went sent a SIGTERM. Possibly due to a conflict with loading appInsights after the app.js load but before the port is setup for listening. Not too sure what causes this bug however. This PR requires further testing.