### PR TITLE
Increase page timeout

### DIFF
--- a/app.js
+++ b/app.js
@@ -84,7 +84,8 @@ onePerPage.journey(app, {
       }
       return key;
     }
-  }
+  },
+  timeoutDelay: config.journey.timeoutDelay
 });
 
 app.use(logging.Express.accessLogger());

--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -51,3 +51,6 @@ services:
     total: RATE_LIMITER_TOTAL
     expire: RATE_LIMITER_EXPIRE
     enabled: RATE_LIMITER_ENABLED
+
+journey:
+  timeoutDelay: JOURNEY_TIMEOUT_DELAY

--- a/config/default.yml
+++ b/config/default.yml
@@ -81,3 +81,6 @@ tests:
 
 features:
   idam: false
+
+journey:
+  timeoutDelay: 150


### PR DESCRIPTION
# Description

If it takes longer than the default one per page wait (50ms) for a page to load, the loading will stop and throw an error.
This is more visible in the E2E tests. I had the following results from implementing a different timeoutDelay for the journey:
1ms - 0/10 Pass
10ms - 5/5 Pass
50ms - 4/5 Pass
100ms - 10/10 Pass

I think 100 ms may be sufficient, as I only recorded a single failure at 50ms, and didn't get a failure at 10ms, although the sample set is extremely small. May require testing on less powerful machines or in a range of different conditions such as multi processing.

To be safe I've set the default timeout to 150ms, which should be enough buffer to cover the above scenarios as well, without impacting the user journey significantly as it is a 100 milliseconds increase.

Fixes # (issue)

[DIV-3114](https://tools.hmcts.net/jira/browse/DIV-3114)

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

All existing unit and e2e tests pass successfully numerous times. Numerous e2e tests were run with differing delay values to see results.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
