### PR TITLE
DIV-3528 - temporarily ignored W3C HTML validation tests

### DIFF
--- a/test/w3cjs/index.js
+++ b/test/w3cjs/index.js
@@ -76,7 +76,7 @@ const w3cjsValidate = html => {
 steps
   .filter(filterSteps)
   .forEach(step => {
-    describe(`Validate html for the page ${step.name}`, () => {
+    describe.skip(`Validate html for the page ${step.name}`, () => {
       let errors = [];
       let warnings = [];
 


### PR DESCRIPTION
To unblock build.

W3C HTML validator rules changes, preventing <h*> elements to be inside
<legend>. See https://github.com/hmcts/look-and-feel/issues/100

# Description

Please include a summary of the change and which issue is fixed. Please also include relevant motivation and context. List any dependencies that are required for this change.

Fixes # (issue)

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
