### PR TITLE
DIV-3766 Apply fix to remove healthcheck for IDAM requiring proxy

### DIFF
--- a/middleware/healthcheck.js
+++ b/middleware/healthcheck.js
@@ -22,14 +22,6 @@ const checks = () => {
           return false;
         });
     }),
-    'idam-authentication': healthcheck.web(config.services.idam.authenticationHealth, {
-      callback: (error, res) => { // eslint-disable-line id-blacklist
-        if (error) {
-          logger.error(`Health check failed on idam-authentication: ${error}`);
-        }
-        return !error && res.status === OK ? outputs.up() : outputs.down(error);
-      }
-    }, options),
     'idam-app': healthcheck.web(config.services.idam.apiHealth, {
       callback: (error, res) => { // eslint-disable-line id-blacklist
         if (error) {

--- a/test/unit/middleware/healthcheck.test.js
+++ b/test/unit/middleware/healthcheck.test.js
@@ -63,7 +63,7 @@ describe(modulePath, () => {
       .then(done, done);
   });
 
-  it('throws an error if healthcheck fails for idam-authentication', () => {
+  it.skip('throws an error if healthcheck fails for idam-authentication', () => {
     setupHealthChecks(app);
 
     const idamCallback = healthcheck.web.firstCall.args[1].callback;
@@ -75,7 +75,7 @@ describe(modulePath, () => {
   it('throws an error if healthcheck fails for idam-app', () => {
     setupHealthChecks(app);
 
-    const idamCallback = healthcheck.web.secondCall.args[1].callback;
+    const idamCallback = healthcheck.web.firstCall.args[1].callback;
     idamCallback('error');
 
     sinon.assert.calledWith(logger.error, 'Health check failed on idam-app: error');


### PR DESCRIPTION
# Description

Recently, DevOps have introduced a proxy requirement for this endpoint (ticket RDO-3077)

The healthcheck module currently doesn't support a proxy, so we're removing this.

Fixes #DIV-3766


## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
