### PR TITLE
Move idam auth to after assets

### DIFF
--- a/app.js
+++ b/app.js
@@ -24,9 +24,6 @@ setupRateLimiter(app);
 // Parsing cookies
 app.use(cookieParser());
 
-// Get user details from idam, sets req.idam.userDetails
-app.use(idam.userDetails());
-
 lookAndFeel.configure(app, {
   baseUrl: '/',
   express: {
@@ -79,6 +76,9 @@ app.use('/public', (req, res) => {
 app.use('/images', (req, res) => {
   res.redirect(`/assets/images${req.path}`, '301');
 });
+
+// Get user details from idam, sets req.idam.userDetails
+app.use(idam.userDetails());
 
 app.set('trust proxy', 1);
 


### PR DESCRIPTION
# Description

[DIV-3646 - Slow pages loads could be result of getting IDAM credentials on every request ( including assets )](https://tools.hmcts.net/jira/browse/DIV-3646)

Move IDAM auth after assets in effort to speed up application.