### PR TITLE
DIV-3812 Revert idam health-check to not need the proxy

### DIFF
--- a/middleware/healthcheck.js
+++ b/middleware/healthcheck.js
@@ -5,7 +5,6 @@ const logger = require('@hmcts/nodejs-logging').Logger.getLogger(__filename);
 const redis = require('services/redis');
 const outputs = require('@hmcts/nodejs-healthcheck/healthcheck/outputs');
 const { OK } = require('http-status-codes');
-const request = require('request-promise-native');
 
 const options = {
   timeout: config.health.timeout,
@@ -15,34 +14,22 @@ const options = {
 const checks = () => {
   return {
     redis: healthcheck.raw(() => {
-      return redis.ping()
-        .then(_ => {
-          return healthcheck.status(_ === 'PONG');
-        })
+      return redis.ping().then(_ => {
+        return healthcheck.status(_ === 'PONG');
+      })
         .catch(error => {
           logger.error(`Health check failed on redis: ${error}`);
-          return healthcheck.status(false);
+          return false;
         });
     }),
-    'idam-web-app': healthcheck.raw(() => {
-      const requestOptions = Object.assign({
-        uri: config.services.idam.authenticationHealth,
-        proxy: config.services.idam.proxy
-      }, options);
-
-      return request.get(
-        config.services.idam.authenticationHealth,
-        requestOptions
-      )
-        .then(body => {
-          const response = JSON.parse(body);
-          return healthcheck.status(response);
-        })
-        .catch(error => {
+    'idam-web-app': healthcheck.web(config.services.idam.authenticationHealth, {
+      callback: (error, res) => { // eslint-disable-line id-blacklist
+        if (error) {
           logger.error(`Health check failed on idam-web-app: ${error}`);
-          return healthcheck.status(false);
-        });
-    }),
+        }
+        return !error && res.status === OK ? outputs.up() : outputs.down(error);
+      }
+    }, options),
     'idam-api': healthcheck.web(config.services.idam.apiHealth, {
       callback: (error, res) => { // eslint-disable-line id-blacklist
         if (error) {


### PR DESCRIPTION
# Description
Revert code to original before using a proxy for IDAM login page health-check

Fixes # DIV-3812

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit and pipeline

**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
