### PR TITLE
DIV-3802 - remove additional answer fields from mini-peition in CYA

### DIFF
--- a/steps/mini-petition/MiniPetition.step.js
+++ b/steps/mini-petition/MiniPetition.step.js
@@ -93,21 +93,6 @@ class MiniPetition extends Question {
         question: this.content.fields.changes.changesDetails.title,
         answer: this.fields.changes.changesDetails.value
       }));
-      answers.push(answer(this, {
-        question: this.content.fields.changes.statementOfTruthChanges.title,
-        answer: this.content.fields
-          .changes.statementOfTruthChanges[
-            this.fields.changes.statementOfTruthChanges.value
-          ]
-      }));
-    } else {
-      answers.push(answer(this, {
-        question: this.content.fields.changes.statementOfTruthNoChanges.title,
-        answer: this.content.fields
-          .changes.statementOfTruthNoChanges[
-            this.fields.changes.statementOfTruthNoChanges.value
-          ]
-      }));
     }
 
     return answers;

--- a/test/unit/steps/miniPetition.test.js
+++ b/test/unit/steps/miniPetition.test.js
@@ -1132,9 +1132,7 @@ describe(modulePath, () => {
         MiniPetitionContent.en.fields.changes.hasBeenChanges.title,
         MiniPetitionContent.en.fields.changes.hasBeenChanges.yes,
         MiniPetitionContent.en.fields.changes.changesDetails.title,
-        'details...',
-        MiniPetitionContent.en.fields.changes.statementOfTruthChanges.title,
-        MiniPetitionContent.en.fields.changes.statementOfTruthChanges.yes
+        'details...'
       ];
       const stepData = {
         changes: {
@@ -1155,9 +1153,7 @@ describe(modulePath, () => {
     it('shows correct answers if user has no changes', () => {
       const expectedContent = [
         MiniPetitionContent.en.fields.changes.hasBeenChanges.title,
-        MiniPetitionContent.en.fields.changes.hasBeenChanges.no,
-        MiniPetitionContent.en.fields.changes.statementOfTruthNoChanges.title,
-        MiniPetitionContent.en.fields.changes.statementOfTruthNoChanges.yes
+        MiniPetitionContent.en.fields.changes.hasBeenChanges.no
       ];
       const stepData = {
         changes: {


### PR DESCRIPTION


# Description

We don't need to have detailed information for statement of truth in CYA

Fixes #DIV-3802

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
