### PR TITLE
DIV-3830: Change to use gmail email address for int tests

### DIFF
--- a/test/functional/helpers/idamHelper.js
+++ b/test/functional/helpers/idamHelper.js
@@ -23,7 +23,7 @@ class IdamHelper extends Helper {
         length: 16,
         charset: 'numeric'
       });
-      const emailName = `hmcts.divorce.reform+automatedtest-${randomString}`;
+      const emailName = `hmcts.divorce.reform+dn-automatedtest-${randomString}`;
       const testEmail = `${emailName}@gmail.com`;
       const testPassword = randomstring.generate(9);
 

--- a/test/functional/helpers/idamHelper.js
+++ b/test/functional/helpers/idamHelper.js
@@ -23,7 +23,7 @@ class IdamHelper extends Helper {
         length: 16,
         charset: 'numeric'
       });
-      const emailName = `hmcts.divorce.reform-${randomString}`;
+      const emailName = `hmcts.divorce.reform+automatedtest-${randomString}`;
       const testEmail = `${emailName}@gmail.com`;
       const testPassword = randomstring.generate(9);
 

--- a/test/functional/helpers/idamHelper.js
+++ b/test/functional/helpers/idamHelper.js
@@ -23,8 +23,8 @@ class IdamHelper extends Helper {
         length: 16,
         charset: 'numeric'
       });
-      const emailName = `simulate-delivered-${randomString}`;
-      const testEmail = `${emailName}@notifications.service.gov.uk`;
+      const emailName = `hmcts.divorce.reform-${randomString}`;
+      const testEmail = `${emailName}@gmail.com`;
       const testPassword = randomstring.generate(9);
 
       idamArgs.testEmail = testEmail;


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-3830

Replace ‘email@email.com’ from emails from integration tests as it is spamming notification service when we run integration tests. 
Created new HMCTS Divorce gmail account for testing with unique users