### PR TITLE
DIV-3916 Update progress-bar to handle when respondent has not admitted fact

### DIFF
--- a/steps/petition-progress-bar/PetitionProgressBar.step.js
+++ b/steps/petition-progress-bar/PetitionProgressBar.step.js
@@ -2,14 +2,15 @@ const { Interstitial } = require('@hmcts/one-per-page/steps');
 const config = require('config');
 const { branch, redirectTo } = require('@hmcts/one-per-page/flow');
 const idam = require('services/idam');
-const { caseStateMap, permitDNReasonMap, caseIdDispalyStateMap } = require('./petitionerStateTemplates');
+const { caseStateMap, permitDNReasonMap, caseIdDisplayStateMap } = require('./petitionerStateTemplates');
 
 const constants = {
   AOSOverdue: 'aosoverdue',
   validAnswer: ['yes', 'no', 'nonoadmission'],
   NotDefined: 'notdefined',
   DNAwaiting: ['dnawaiting', 'awaitingdecreenisi'],
-  undefendedReason: '0'
+  undefendedReason: '0',
+  yes: 'yes'
 };
 
 class PetitionProgressBar extends Interstitial {
@@ -26,7 +27,11 @@ class PetitionProgressBar extends Interstitial {
   }
 
   get isCaseIdToBeDisplayed() {
-    return caseIdDispalyStateMap.includes(this.caseState);
+    return caseIdDisplayStateMap.includes(this.caseState);
+  }
+
+  get respondentAdmitsToFact() {
+    return this.case.respAdmitOrConsentToFact && this.case.respAdmitOrConsentToFact.toLowerCase() === constants.yes;
   }
 
   handler(req, res) {

--- a/steps/petition-progress-bar/petitionerStateTemplates.js
+++ b/steps/petition-progress-bar/petitionerStateTemplates.js
@@ -25,7 +25,7 @@ const caseStateMap = [
   }
 ];
 
-const caseIdDispalyStateMap = ['submitted', 'awaitinghwfdecision', 'awaitingdocuments', 'pendingrejection', 'petitioncompleted'];
+const caseIdDisplayStateMap = ['submitted', 'awaitinghwfdecision', 'awaitingdocuments', 'pendingrejection', 'petitioncompleted'];
 
 const permitDNReasonMap = new Map([
   ['0', './sections/undefended/PetitionProgressBar.undefended.template.html'],
@@ -35,4 +35,4 @@ const permitDNReasonMap = new Map([
   ['4', './sections/defendedWithoutAnswer/PetitionProgressBar.defendedWithoutAnswer.template.html']
 ]);
 
-module.exports = { caseStateMap, permitDNReasonMap, caseIdDispalyStateMap };
+module.exports = { caseStateMap, permitDNReasonMap, caseIdDisplayStateMap };

--- a/steps/petition-progress-bar/sections/undefended/PetitionProgressBar.content.undefended.json
+++ b/steps/petition-progress-bar/sections/undefended/PetitionProgressBar.content.undefended.json
@@ -1,6 +1,7 @@
 {
   "en": {
     "undefendedAppStatusMsg": "You can continue with your divorce",
+    "undefendedButNotAdmit": "Your {{ case.divorceWho }} has responded to your application and said that they don't intend to defend the divorce (they won't try to prevent it), but doesn't accept the allegations made in the application.",
     "undefendedAppStatusMsgDetails1": "Your {{ case.divorceWho }} has responded to your application and said that they don't intend to defend the divorce (they won't try to prevent it).",
     "undefendedAppStatusMsgDetails2": "You can now continue with the next stage and apply for your decree nisi.",
     "undefendedReadMore": "Read more about the decree nisi",

--- a/steps/petition-progress-bar/sections/undefended/PetitionProgressBar.undefended.template.html
+++ b/steps/petition-progress-bar/sections/undefended/PetitionProgressBar.undefended.template.html
@@ -21,7 +21,11 @@
 
 <h2 class="heading-medium">{{ content.undefendedAppStatusMsg }}</h2>
 
-<p>{{ content.undefendedAppStatusMsgDetails1 }}</p>
+{% if respondentAdmitsToFact %}
+  <p>{{ content.undefendedAppStatusMsgDetails1 }}</p>
+{% else %}
+  <p>{{ content.undefendedButNotAdmit }}</p>
+{% endif %}
 <p>{{ content.undefendedAppStatusMsgDetails2 }}</p>
 
 <details>

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -158,6 +158,36 @@ describe(modulePath, () => {
       const instance = stepAsInstance(PetitionProgressBar, session);
       expect(instance.stateTemplate).to.eql(templates.undefended);
     });
+
+    it('renders content for when respondent does not admit fact', () => {
+      const noAdmitSession = {
+        case: {
+          state: 'DNawaiting',
+          data: {
+            permittedDecreeNisiReason: '0',
+            respAdmitOrConsentToFact: 'No'
+          }
+        }
+      };
+      const specificContent = ['undefendedButNotAdmit'];
+
+      return content(PetitionProgressBar, noAdmitSession, { specificContent });
+    });
+
+    it('renders content for when respondent does admit fact', () => {
+      const yesAdmitSession = {
+        case: {
+          state: 'DNawaiting',
+          data: {
+            permittedDecreeNisiReason: '0',
+            respAdmitOrConsentToFact: 'Yes'
+          }
+        }
+      };
+      const specificContent = ['undefendedAppStatusMsgDetails1'];
+
+      return content(PetitionProgressBar, yesAdmitSession, { specificContent });
+    });
   });
 
   describe('CCD state: DNawaiting, DNReason : 1 ', () => {


### PR DESCRIPTION
# Description

Handle when petitioner logs in and sees progress bar page, and the respondent is not defending but does not admit to fact (accusation).

Fixes # DIV-3916

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Unit tested

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
