### PR TITLE
DIV-4234 - date of last behaviour incident can be since date of marriage

### DIFF
--- a/steps/behaviour-continued-since-application/BehaviourContinuedSinceApplication.content.json
+++ b/steps/behaviour-continued-since-application/BehaviourContinuedSinceApplication.content.json
@@ -6,7 +6,7 @@
     "detailsAboutLastIncidentDateDetail" : "If you're not sure of the exact date, use the closest date you remember.",
     "errors": {
       "required": "Select yes if your {{ case.divorceWho }}'s behaviour still continuing?",
-      "requireLastIncidentDate": "Enter a date between the day you submitted your application and today’s date."
+      "requireLastIncidentDate": "Enter a date between the date of your marriage and today’s date."
     },
     "fields": {
       "changes": {

--- a/steps/behaviour-continued-since-application/BehaviourContinuedSinceApplication.step.js
+++ b/steps/behaviour-continued-since-application/BehaviourContinuedSinceApplication.step.js
@@ -30,10 +30,10 @@ class BehaviourContinuedSinceApplication extends Question {
       }
       const hasAnsweredYes = behaviourContinuedSinceApplication === 'yes';
       const hasAnsweredNo = behaviourContinuedSinceApplication === 'no';
-      const lastSubmittedDate = moment(this.case.createdDate).format('YYYY-MM-DD');
+      const marriageDate = moment(this.case.marriageDate).format('YYYY-MM-DD');
 
       const hasGivenDate = this.fields.changes.lastIncidentDate.day.value && this.fields.changes.lastIncidentDate.month.value && this.fields.changes.lastIncidentDate.year.value
-       && lastIncidentDate.isValid() && lastIncidentDate.isBetween(lastSubmittedDate, moment.now(), null, []); // eslint-disable-line
+       && lastIncidentDate.isValid() && lastIncidentDate.isBetween(marriageDate, moment.now(), null, []); // eslint-disable-line
       return hasAnsweredYes || (hasAnsweredNo && hasGivenDate);
     };
 

--- a/test/unit/steps/behaviourContinuedSinceApplication.test.js
+++ b/test/unit/steps/behaviourContinuedSinceApplication.test.js
@@ -33,9 +33,7 @@ describe(modulePath, () => {
     const onlyErrors = ['required'];
     const session = {
       case: {
-        data: {
-          createdDate: '2018-08-02T00:00:00.000Z'
-        }
+        data: {}
       }
     };
     return question.testErrors(BehaviourContinuedSinceApplication, session, {}, { onlyErrors });
@@ -47,24 +45,22 @@ describe(modulePath, () => {
       'changes.lastIncidentDate-day': '' };
     const session = {
       case: {
-        data: {
-          createdDate: '2018-08-02T00:00:00.000Z'
-        }
+        data: {}
       }
     };
     return question.testErrors(BehaviourContinuedSinceApplication, session, fields, { onlyErrors });
   });
 
-  it('shows error if answered no and a date before last application date is entered', () => {
+  it('shows error if answered no and a date before marriage date is entered', () => {
     const onlyErrors = ['requireLastIncidentDate'];
     const fields = { 'changes.behaviourContinuedSinceApplication': 'no',
       'changes.lastIncidentDate-day': '20',
       'changes.lastIncidentDate-month': '03',
-      'changes.lastIncidentDate-year': '1900' };
+      'changes.lastIncidentDate-year': '2016' };
     const session = {
       case: {
         data: {
-          createdDate: '2018-08-02T00:00:00.000Z'
+          marriageDate: '2018-08-02T00:00:00.000Z'
         }
       }
     };
@@ -79,9 +75,7 @@ describe(modulePath, () => {
       'changes.lastIncidentDate-year': '2200' };
     const session = {
       case: {
-        data: {
-          createdDate: '2018-08-02T00:00:00.000Z'
-        }
+        data: { }
       }
     };
     return question.testErrors(BehaviourContinuedSinceApplication, session, fields, { onlyErrors });
@@ -91,10 +85,11 @@ describe(modulePath, () => {
     const fields = { 'changes.behaviourContinuedSinceApplication': 'no',
       'changes.lastIncidentDate.day': '20',
       'changes.lastIncidentDate.month': '09',
-      'changes.lastIncidentDate.year': '2018' };
+      'changes.lastIncidentDate.year': '2017' };
     const session = {
       case: {
         data: {
+          marriageDate: '2016-08-02T00:00:00.000Z',
           createdDate: '2018-08-02T00:00:00.000Z'
         }
       }
@@ -161,9 +156,7 @@ describe(modulePath, () => {
 
     const session = {
       case: {
-        data: {
-          createdDate: '2018-08-02T00:00:00.000Z'
-        }
+        data: {}
       }
     };
 
@@ -184,9 +177,7 @@ describe(modulePath, () => {
 
     const session = {
       case: {
-        data: {
-          createdDate: '2018-08-02T00:00:00.000Z'
-        }
+        data: {}
       }
     };
 


### PR DESCRIPTION
# Description

Changed the logic for the date entry and error checking to limit entered
dates to between Date of Marriage and Today's Date, including both of
those actual dates.

Fixes #DIV-4234

## Type of change


- [x] New feature (non-breaking change which adds functionality)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
