### PR TITLE
DN- Adding adultery  second hand info in mini petiiton

### DIFF
--- a/mocks/services/case-orchestration/retrieve-case/mock-case.json
+++ b/mocks/services/case-orchestration/retrieve-case/mock-case.json
@@ -146,6 +146,8 @@
     "reasonForDivorceAdulteryKnowWhere": "Yes",
     "reasonForDivorceAdulteryWhereDetails": "Where the adultery happened",
     "reasonForDivorceAdulteryWhenDetails": "When the adultery happened",
+    "reasonForDivorceAdulterySecondHandInfo": "Yes",
+    "reasonForDivorceAdulterySecondHandInfoDetails": "A trusted source of mine gave me this information",
     "reasonForDivorceAdulteryIsNamed": "Yes",
     "financialOrder": "Yes",
     "financialOrderFor": [

--- a/steps/mini-petition/MiniPetition.content.json
+++ b/steps/mini-petition/MiniPetition.content.json
@@ -29,6 +29,7 @@
     "reasonForDivorceAdulteryWhere": "Where the adultery took place",
     "reasonForDivorceAdulteryWhen": "When the adultery took place",
     "reasonForDivorceAdulteryDescription": "Description of the adultery",
+    "statementOfSecondHandInformationAboutAdultery": "The applicant stated that some of this information was given to them by another person and provided the following details:",
     "reasonForDivorceInfo": "The marriage has broken down irretrievably. The applicant is relying on the following fact to support their application.",
     "reasonForDivorceUnreasonableBehaviourBrokenDown": "The respondent has behaved in such a way that the applicant cannot reasonably be expected to live with the respondent.",
     "reasonForDivorceUnreasonableBehaviourStatment": "This is supported by the following statement from the applicant.",

--- a/steps/mini-petition/MiniPetition.html
+++ b/steps/mini-petition/MiniPetition.html
@@ -277,6 +277,8 @@
 
     <h3 class="heading-small">{{ content.reasonForDivorceAdulteryDescription }}</h3>
     <p class="text">"{{ case.reasonForDivorceAdulteryDetails }}"</p>
+    <p class="text">{{ content.statementOfSecondHandInformationAboutAdultery }}</p>
+    <p class="text">"{{ case.reasonForDivorceAdulterySecondHandInfoDetails }}"</p>
   {% endif %}
 
 

--- a/test/unit/steps/miniPetition.test.js
+++ b/test/unit/steps/miniPetition.test.js
@@ -425,7 +425,9 @@ describe(modulePath, () => {
             reasonForDivorceAdulteryKnowWhen: 'Yes',
             reasonForDivorceAdulteryDetails: 'Here are some adultery details',
             reasonForDivorceAdulteryWhereDetails: 'Where the adultery happened',
-            reasonForDivorceAdulteryWhenDetails: 'When the adultery happened'
+            reasonForDivorceAdulteryWhenDetails: 'When the adultery happened',
+            reasonForDivorceAdulterySecondHandInfo: 'Yes',
+            reasonForDivorceAdulterySecondHandInfoDetails: 'A trusted source'
           }
         }
       };
@@ -436,7 +438,8 @@ describe(modulePath, () => {
           specificValues: [
             session.case.reasonForDivorceAdulteryDetails,
             session.case.reasonForDivorceAdulteryWhereDetails,
-            session.case.reasonForDivorceAdulteryWhenDetails
+            session.case.reasonForDivorceAdulteryWhenDetails,
+            session.case.reasonForDivorceAdulterySecondHandInfoDetails
           ]
         }
       );
@@ -494,6 +497,7 @@ describe(modulePath, () => {
         'reasonForDivorceAdulteryWhere',
         'reasonForDivorceAdulteryWhen',
         'reasonForDivorceAdulteryDescription',
+        'statementOfSecondHandInformationAboutAdultery',
         'reasonForDivorceInfo',
         'reasonForDivorceStatement',
         'reasonForDivorceSeperationTwoYearsDecidedDate',

--- a/test/unit/steps/miniPetition.test.js
+++ b/test/unit/steps/miniPetition.test.js
@@ -358,8 +358,8 @@ describe(modulePath, () => {
         session,
         {
           specificValues: [
-            session.case.reasonForDivorceAdultery3rdPartyFirstName,
-            session.case.reasonForDivorceAdultery3rdPartyLastName
+            session.case.data.reasonForDivorceAdultery3rdPartyFirstName,
+            session.case.data.reasonForDivorceAdultery3rdPartyLastName
           ]
         }
       );
@@ -458,7 +458,7 @@ describe(modulePath, () => {
       return content(
         MiniPetition,
         session,
-        { specificValues: [session.case.reasonForDivorceBehaviourDetails] }
+        { specificValues: [session.case.data.reasonForDivorceBehaviourDetails] }
       );
     });
 
@@ -475,7 +475,7 @@ describe(modulePath, () => {
       return content(
         MiniPetition,
         session,
-        { specificValues: [session.case.reasonForDivorceDesertionDetails] }
+        { specificValues: [session.case.data.reasonForDivorceDesertionDetails] }
       );
     });
   });

--- a/test/unit/steps/miniPetition.test.js
+++ b/test/unit/steps/miniPetition.test.js
@@ -871,6 +871,27 @@ describe(modulePath, () => {
               'reasonForDivorceAdulteryDescription'
             ] });
         });
+        it('knows where & second hand info ', () => {
+          const session = {
+            case: {
+              data: {
+                connections: {},
+                reasonForDivorce: 'adultery',
+                reasonForDivorceAdulteryKnowWhere: 'Yes',
+                reasonForDivorceAdulterySecondHandInfo: 'Yes'
+              }
+            }
+          };
+          return content(
+            MiniPetition,
+            session,
+            { specificContent: [
+              'reasonForDivorceAdulteryWhere',
+              'reasonForDivorceStatement',
+              'reasonForDivorceAdulteryDescription',
+              'statementOfSecondHandInformationAboutAdultery'
+            ] });
+        });
         it('knows when', () => {
           const session = {
             case: {

--- a/test/unit/steps/miniPetition.test.js
+++ b/test/unit/steps/miniPetition.test.js
@@ -436,10 +436,10 @@ describe(modulePath, () => {
         session,
         {
           specificValues: [
-            session.case.reasonForDivorceAdulteryDetails,
-            session.case.reasonForDivorceAdulteryWhereDetails,
-            session.case.reasonForDivorceAdulteryWhenDetails,
-            session.case.reasonForDivorceAdulterySecondHandInfoDetails
+            session.case.data.reasonForDivorceAdulteryDetails,
+            session.case.data.reasonForDivorceAdulteryWhereDetails,
+            session.case.data.reasonForDivorceAdulteryWhenDetails,
+            session.case.data.reasonForDivorceAdulterySecondHandInfoDetails
           ]
         }
       );


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-4370

If the value of D8ReasonForDivorceAdulteryAnyInfo2ndHand is 'No', no additional content shows on the mini-petition.

If the value of D8ReasonForDivorceAdulteryAnyInfo2ndHand is 'Yes', additional content will show on the mini-petition as follows:

Fixed text of: "The applicant stated that some of this information was given to them by another person and provided the following details:"
Variable text as contained in the field D8ReasonForDivorceAdultery2ndHandDetails 