### PR TITLE
Div 4450  Change DN workflow to display Resp/CoResp responses before showing amend petition

### DIFF
--- a/steps/resp-not-admit-adultery/RespNotAdmitAdultery.step.js
+++ b/steps/resp-not-admit-adultery/RespNotAdmitAdultery.step.js
@@ -17,14 +17,6 @@ class RespNotAdmitAdultery extends Question {
     return this.req.session.case.data;
   }
 
-  get adulteryWishToName() {
-    return this.case.reasonForDivorceAdulteryWishToName === 'Yes';
-  }
-
-  get recievedAosFromCoResp() {
-    return this.case.coRespondentAnswers && this.case.coRespondentAnswers.aos.received === 'Yes';
-  }
-
   get form() {
     const answers = ['yes', 'no'];
     const validAnswers = Joi.string()
@@ -50,15 +42,9 @@ class RespNotAdmitAdultery extends Question {
       return this.fields.amendPetition.value === 'yes';
     };
 
-    const reviewAosRespCoRespondent = () => {
-      return this.fields.amendPetition.value === 'no' && this.recievedAosFromCoResp && this.adulteryWishToName;
-    };
-
     return branch(
       redirectTo(this.journey.steps.AmendApplication)
         .if(parseBool(config.features.release520) && amendPetition),
-      redirectTo(this.journey.steps.ReviewAosResponseFromCoRespondent)
-        .if(parseBool(config.features.release520) && reviewAosRespCoRespondent),
       redirectTo(this.journey.steps.ApplyForDecreeNisi)
     );
   }

--- a/steps/review-aos-response-from-co-respondent/ReviewAosResponseFromCoRespondent.step.js
+++ b/steps/review-aos-response-from-co-respondent/ReviewAosResponseFromCoRespondent.step.js
@@ -9,7 +9,8 @@ const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
 
 const constants = {
   respAdmitOrConsentToFact: 'respAdmitOrConsentToFact',
-  no: 'No'
+  no: 'No',
+  AosCompleted: 'AosCompleted'
 };
 class ReviewAosResponseFromCoRespondent extends Question {
   static get path() {
@@ -48,7 +49,7 @@ class ReviewAosResponseFromCoRespondent extends Question {
 
   next() {
     const respNotAdmitAdultery = () => {
-      return this.case[constants.respAdmitOrConsentToFact] === constants.no;
+      return this.case[constants.respAdmitOrConsentToFact] === constants.no && this.req.session.case.state === constants.AosCompleted;
     };
 
     return branch(

--- a/steps/review-aos-response/ReviewAosResponse.step.js
+++ b/steps/review-aos-response/ReviewAosResponse.step.js
@@ -25,7 +25,8 @@ const constants = {
   adultery: 'adultery',
   yes: 'Yes',
   no: 'No',
-  notAccept: 'NoNoAdmission'
+  notAccept: 'NoNoAdmission',
+  AosCompleted: 'AosCompleted'
 };
 
 class ReviewAosResponse extends Question {
@@ -94,7 +95,7 @@ class ReviewAosResponse extends Question {
 
   next() {
     const respNotAdmitAdultery = () => {
-      return this.adultery && this.notExist(this.consts.respAdmitOrConsentToFact);
+      return this.adultery && this.notExist(this.consts.respAdmitOrConsentToFact) && this.req.session.case.state === this.consts.AosCompleted;
     };
 
     const ammendAplication = () => {

--- a/steps/review-aos-response/ReviewAosResponse.step.js
+++ b/steps/review-aos-response/ReviewAosResponse.step.js
@@ -81,7 +81,7 @@ class ReviewAosResponse extends Question {
     return this.case.reasonForDivorceAdulteryWishToName && this.case.reasonForDivorceAdulteryWishToName === this.consts.yes;
   }
 
-  get recievedAosFromCoResp() {
+  get receivedAosFromCoResp() {
     return this.case.coRespondentAnswers && this.case.coRespondentAnswers.aos.received === this.consts.yes;
   }
 
@@ -102,16 +102,16 @@ class ReviewAosResponse extends Question {
     };
 
     const reviewAosRespCoRespondent = () => {
-      return this.adultery && this.adulteryWishToName && this.recievedAosFromCoResp && this.exist(this.consts.respAdmitOrConsentToFact);
+      return this.adultery && this.adulteryWishToName && this.receivedAosFromCoResp;
     };
 
     return branch(
       redirectTo(this.journey.steps.AmendApplication)
         .if(parseBool(config.features.release520) && ammendAplication),
-      redirectTo(this.journey.steps.RespNotAdmitAdultery)
-        .if(parseBool(config.features.release520) && respNotAdmitAdultery),
       redirectTo(this.journey.steps.ReviewAosResponseFromCoRespondent)
         .if(parseBool(config.features.release520) && reviewAosRespCoRespondent),
+      redirectTo(this.journey.steps.RespNotAdmitAdultery)
+        .if(parseBool(config.features.release520) && respNotAdmitAdultery),
       redirectTo(this.journey.steps.ApplyForDecreeNisi)
     );
   }

--- a/test/e2e/journeys/DivorceReasons/adultery.test.js
+++ b/test/e2e/journeys/DivorceReasons/adultery.test.js
@@ -245,8 +245,8 @@ describe('Respondent Admitted Adultery : no', () => {
       { step: Entry },
       { step: petitionProgressBar },
       { step: reviewAosResponse, body: { reviewAosResponse: 'yes' } },
-      { step: respNotAdmitAdultery, body: { amendPetition: 'no' } },
       { step: ReviewAosResponseFromCoRespondent, body: { reviewAosCRResponse: 'yes' } },
+      { step: respNotAdmitAdultery, body: { amendPetition: 'no' } },
       { step: ApplyForDecreeNisi, body: { applyForDecreeNisi: 'yes' } },
       {
         step: MiniPetition,
@@ -336,8 +336,8 @@ describe('Respondent Admitted Adultery : no, AdulteryWishToName: Yes', () => {
       { step: Entry },
       { step: petitionProgressBar },
       { step: reviewAosResponse, body: { reviewAosResponse: 'yes' } },
-      { step: respNotAdmitAdultery, body: { amendPetition: 'no' } },
       { step: ReviewAosResponseFromCoRespondent, body: { reviewAosCRResponse: 'yes' } },
+      { step: respNotAdmitAdultery, body: { amendPetition: 'no' } },
       { step: ApplyForDecreeNisi }
 
     ]);

--- a/test/e2e/journeys/DivorceReasons/adultery.test.js
+++ b/test/e2e/journeys/DivorceReasons/adultery.test.js
@@ -214,7 +214,7 @@ describe('Respondent Admitted Adultery : no', () => {
       .withArgs(sinon.match({
         uri: `${config.services.orchestrationService.getCaseUrl}`
       }))
-      .resolves(merge({}, mockCaseResponse, { data: sess }));
+      .resolves(merge({}, mockCaseResponse, { state: 'AosCompleted', data: sess }));
 
     caseOrchestrationServiceSubmitStub = postStub
       .withArgs(sinon.match({
@@ -313,7 +313,7 @@ describe('Respondent Admitted Adultery : no, AdulteryWishToName: Yes', () => {
       .withArgs(sinon.match({
         uri: `${config.services.orchestrationService.getCaseUrl}`
       }))
-      .resolves(merge({}, mockCaseResponse, { data: sess }));
+      .resolves(merge({}, mockCaseResponse, { state: 'AosCompleted', data: sess }));
     sinon.stub(feesAndPaymentsService, 'getFee')
       .resolves({
         feeCode: 'FEE0002',

--- a/test/unit/steps/respNotAdmitAdultery.test.js
+++ b/test/unit/steps/respNotAdmitAdultery.test.js
@@ -6,8 +6,6 @@ const RespNotAdmitAdulteryContent = require(
 );
 const ApplyForDecreeNisi = require('steps/apply-for-decree-nisi/ApplyForDecreeNisi.step');
 const AmendApplication = require('steps/amend-application/AmendApplication.step');
-// eslint-disable-next-line max-len
-const ReviewAosResponseFromCoRespondent = require('steps/review-aos-response-from-co-respondent/ReviewAosResponseFromCoRespondent.step');
 const idam = require('services/idam');
 const { middleware, sinon, content, question } = require('@hmcts/one-per-page-test-suite');
 const config = require('config');
@@ -96,26 +94,6 @@ describe(modulePath, () => {
       sandbox.replace(config.features, 'release520', true);
       const fields = { amendPetition: 'yes' };
       return question.redirectWithField(RespNotAdmitAdultery, fields, AmendApplication);
-    });
-
-    it('redirects to ReviewAosResponseFromCoRespondent page', () => {
-      sandbox.replace(config.features, 'release520', true);
-      const fields = { amendPetition: 'no' };
-      const session = {
-        case: {
-          data: {
-            reasonForDivorce: 'adultery',
-            reasonForDivorceAdulteryWishToName: 'Yes',
-            coRespondentAnswers: {
-              aos: {
-                received: 'Yes'
-              }
-            }
-          }
-        }
-      };
-      // eslint-disable-next-line max-len
-      return question.redirectWithField(RespNotAdmitAdultery, fields, ReviewAosResponseFromCoRespondent, session);
     });
   });
 });

--- a/test/unit/steps/reviewAosResponse.test.js
+++ b/test/unit/steps/reviewAosResponse.test.js
@@ -113,7 +113,7 @@ describe(modulePath, () => {
       return question.redirectWithField(ReviewAosResponse, fields, ApplyForDecreeNisi, session);
     });
 
-    it('redirects to RespNotAdmitAdultery page', () => {
+    it('redirects to RespNotAdmitAdultery page - CoRespondent Answers not received', () => {
       sandbox.replace(config.features, 'release520', true);
 
       const fields = { reviewAosResponse: 'yes' };
@@ -502,7 +502,7 @@ describe(modulePath, () => {
         sandbox.restore();
       });
 
-      it('redirects to ReviewAosResponseFromCoRespondent page', () => {
+      it('redirects to CoRespondent response - respAdmitOrConsentToFact: Yes', () => {
         sandbox.replace(config.features, 'release520', true);
 
         const fields = { reviewAosResponse: 'yes' };
@@ -512,6 +512,28 @@ describe(modulePath, () => {
               reasonForDivorce: 'adultery',
               reasonForDivorceAdulteryWishToName: 'Yes',
               respAdmitOrConsentToFact: 'Yes',
+              coRespondentAnswers: {
+                aos: {
+                  received: 'Yes'
+                }
+              }
+            }
+          }
+        };
+        // eslint-disable-next-line max-len
+        return question.redirectWithField(ReviewAosResponse, fields, ReviewAosResponseFromCoRespondent, session);
+      });
+
+      it('redirects to CoRespondent response - respAdmitOrConsentToFact: No', () => {
+        sandbox.replace(config.features, 'release520', true);
+
+        const fields = { reviewAosResponse: 'yes' };
+        const session = {
+          case: {
+            data: {
+              reasonForDivorce: 'adultery',
+              reasonForDivorceAdulteryWishToName: 'Yes',
+              respAdmitOrConsentToFact: 'No',
               coRespondentAnswers: {
                 aos: {
                   received: 'Yes'

--- a/test/unit/steps/reviewAosResponse.test.js
+++ b/test/unit/steps/reviewAosResponse.test.js
@@ -113,9 +113,23 @@ describe(modulePath, () => {
       return question.redirectWithField(ReviewAosResponse, fields, ApplyForDecreeNisi, session);
     });
 
-    it('redirects to RespNotAdmitAdultery page - CoRespondent Answers not received', () => {
+    it('redirects to RespNotAdmitAdultery page - state: AosCompleted', () => {
       sandbox.replace(config.features, 'release520', true);
 
+      const fields = { reviewAosResponse: 'yes' };
+      const session = {
+        case: {
+          state: 'AosCompleted',
+          data: {
+            reasonForDivorce: 'adultery',
+            respAdmitOrConsentToFact: 'No'
+          }
+        }
+      };
+      return question.redirectWithField(ReviewAosResponse, fields, RespNotAdmitAdultery, session);
+    });
+
+    it('redirects to ApplyForDecreeNisi page - state is not matching with AOS completed', () => {
       const fields = { reviewAosResponse: 'yes' };
       const session = {
         case: {
@@ -125,7 +139,7 @@ describe(modulePath, () => {
           }
         }
       };
-      return question.redirectWithField(ReviewAosResponse, fields, RespNotAdmitAdultery, session);
+      return question.redirectWithField(ReviewAosResponse, fields, ApplyForDecreeNisi, session);
     });
   });
 

--- a/test/unit/steps/reviewAosResponseFromCoRespondent.test.js
+++ b/test/unit/steps/reviewAosResponseFromCoRespondent.test.js
@@ -232,12 +232,13 @@ describe(modulePath, () => {
       sandbox.restore();
     });
 
-    it('To RespNotAdmitAdultery page - CoRespondent Answers not received', () => {
+    it('To RespNotAdmitAdultery page - No CoRespondent Answers, state: AosCompleted', () => {
       sandbox.replace(config.features, 'release520', true);
 
       const fields = { reviewAosCRResponse: 'yes' };
       const session = {
         case: {
+          state: 'AosCompleted',
           data: {
             reasonForDivorce: 'adultery',
             respAdmitOrConsentToFact: 'No',
@@ -255,6 +256,32 @@ describe(modulePath, () => {
         ReviewAosResponseFromCoRespondent,
         fields,
         RespNotAdmitAdultery,
+        session
+      );
+    });
+
+    it('To ApplyForDecreeNisi page - CoRespondent Answers not received, state: AwaitingDN', () => {
+      const fields = { reviewAosCRResponse: 'yes' };
+      const session = {
+        case: {
+          state: 'AwaitingDN',
+          data: {
+            reasonForDivorce: 'adultery',
+            respAdmitOrConsentToFact: 'No',
+            coRespondentAnswers: {
+              admitAdultery: 'Yes',
+              defendsDivorce: 'Yes',
+              costs: {
+                agreeToCosts: 'Yes'
+              }
+            }
+          }
+        }
+      };
+      return question.redirectWithField(
+        ReviewAosResponseFromCoRespondent,
+        fields,
+        ApplyForDecreeNisi,
         session
       );
     });

--- a/test/unit/steps/reviewAosResponseFromCoRespondent.test.js
+++ b/test/unit/steps/reviewAosResponseFromCoRespondent.test.js
@@ -8,7 +8,10 @@ const ReviewCRContent = require(
 const idam = require('services/idam');
 const { middleware, sinon, content, question } = require('@hmcts/one-per-page-test-suite');
 const ApplyForDecreeNisi = require('steps/apply-for-decree-nisi/ApplyForDecreeNisi.step');
-
+const RespNotAdmitAdultery = require(
+  'steps/resp-not-admit-adultery/RespNotAdmitAdultery.step'
+);
+const config = require('config');
 
 describe(modulePath, () => {
   beforeEach(() => {
@@ -220,5 +223,63 @@ describe(modulePath, () => {
       ApplyForDecreeNisi,
       session
     );
+  });
+
+  describe('Redirects', () => {
+    const sandbox = sinon.createSandbox();
+
+    after(() => {
+      sandbox.restore();
+    });
+
+    it('To RespNotAdmitAdultery page - CoRespondent Answers not received', () => {
+      sandbox.replace(config.features, 'release520', true);
+
+      const fields = { reviewAosCRResponse: 'yes' };
+      const session = {
+        case: {
+          data: {
+            reasonForDivorce: 'adultery',
+            respAdmitOrConsentToFact: 'No',
+            coRespondentAnswers: {
+              admitAdultery: 'Yes',
+              defendsDivorce: 'Yes',
+              costs: {
+                agreeToCosts: 'Yes'
+              }
+            }
+          }
+        }
+      };
+      return question.redirectWithField(
+        ReviewAosResponseFromCoRespondent,
+        fields,
+        RespNotAdmitAdultery,
+        session
+      );
+    });
+
+    it('navigates to ApplyForDecreeNisi page', () => {
+      const fields = { reviewAosCRResponse: 'yes' };
+      const session = {
+        case: {
+          data: {
+            coRespondentAnswers: {
+              admitAdultery: 'Yes',
+              defendsDivorce: 'Yes',
+              costs: {
+                agreeToCosts: 'Yes'
+              }
+            }
+          }
+        }
+      };
+      return question.redirectWithField(
+        ReviewAosResponseFromCoRespondent,
+        fields,
+        ApplyForDecreeNisi,
+        session
+      );
+    });
   });
 });


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-4450

The Co-Respondent has submitted a response is the field ReceivedAosFromCoResp is set to 'Yes'.  In this case, the workflow should be:

Review Respondent's answers: /review-aos-response 
Review Co-Respondent's answers: /review-aos-response-from-corespondent 
Choose option on reason: /resp-does-not-admit-adultery-options {Petitioner selects a 'Keep' or 'Change' option}
[Keep] routes to /continue-with-divorce 
[Change] routes to /amend-application 