### PR TITLE
If respondentAnswer is not available the CYA page should not be blocked

### DIFF
--- a/steps/review-aos-response/ReviewAosResponse.step.js
+++ b/steps/review-aos-response/ReviewAosResponse.step.js
@@ -134,9 +134,7 @@ class ReviewAosResponse extends Question {
     ];
     return answer(this, {
       question: this.content.fields.reviewAosResponse.title,
-      answer: this.content.fields.reviewAosResponse[
-        respondentAnswer ? respondentAnswer.toLowerCase() : ''
-      ]
+      answer: respondentAnswer ? this.content.fields.reviewAosResponse[respondentAnswer.toLowerCase()] : ''
     });
   }
 


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-4543

In CCD the respWillDefendDivorce is optional and in petitioner page we are redirectign to  reviewAOSResponse even if  the respWillDefendDivorce is null and state is AOSCompleted / 2 yr separation.  There is a chance that answer is not available and showing translation errors on CYA page.