### PR TITLE
Adultery - Defending without answer, CoResp Not replied content change

### DIFF
--- a/steps/petition-progress-bar/PetitionProgressBar.step.js
+++ b/steps/petition-progress-bar/PetitionProgressBar.step.js
@@ -104,6 +104,14 @@ class PetitionProgressBar extends Interstitial {
     return this.case.permittedDecreeNisiReason ? this.case.permittedDecreeNisiReason : constants.undefendedReason;
   }
 
+  get isCoRespNotResponded() {
+    return this.case.reasonForDivorce === constants.adultery && this.case.reasonForDivorceAdulteryWishToName && this.case.reasonForDivorceAdulteryWishToName.toLowerCase() === constants.yes && !this.receivedAosFromCoResp;
+  }
+
+  get receivedAosFromCoResp() {
+    return this.case.coRespondentAnswers && this.case.coRespondentAnswers.aos.received && this.case.coRespondentAnswers.aos.received.toLowerCase() === constants.yes;
+  }
+
   get stateTemplate() {
     let template = '';
     if (constants.DNAwaiting.includes(this.caseState)) {

--- a/steps/petition-progress-bar/sections/defendedWithoutAnswer/PetitionProgressBar.content.defendedWithoutAnswer.json
+++ b/steps/petition-progress-bar/sections/defendedWithoutAnswer/PetitionProgressBar.content.defendedWithoutAnswer.json
@@ -2,6 +2,7 @@
   "en": {
     "dWAAppStatusMsg": "You can continue with your divorce",
     "dWAAppStatusMsgDetails1": "Your {{ case.divorceWho }} has missed the deadline to submit the form which would have made their case for defending (trying to prevent) the divorce.",
+    "dWAAppStatusMsgCoRespDetails": "The co-respondent has not yet responded to your divorce application. You can choose to wait until they have submitted their response before continuing",
     "dWAAppStatusMsgDetails2": "This means that you can now continue with your divorce as if they hadn't said that they intended to defend."
   }
 }

--- a/steps/petition-progress-bar/sections/defendedWithoutAnswer/PetitionProgressBar.defendedWithoutAnswer.template.html
+++ b/steps/petition-progress-bar/sections/defendedWithoutAnswer/PetitionProgressBar.defendedWithoutAnswer.template.html
@@ -22,6 +22,11 @@
 
 <h2 class="heading-medium">{{ content.dWAAppStatusMsg }}</h2>
 <p>{{ content.dWAAppStatusMsgDetails1 }}</p>
+
+{% if isCoRespNotResponded %}
+  <p>{{ content.dWAAppStatusMsgCoRespDetails }}</p>
+{% endif %}
+
 <p>{{ content.dWAAppStatusMsgDetails2 }}</p>
 
 <br>

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -272,6 +272,60 @@ describe(modulePath, () => {
     });
   });
 
+  describe('CCD state: DNawaiting, CoResp Replied, DNReason : 3 ', () => {
+    const session = {
+      case: {
+        state: 'AwaitingDecreeNisi',
+        reasonForDivorce: 'adultery',
+        reasonForDivorceAdulteryWishToName: 'Yes',
+        coRespondentAnswers: {
+          aos: {
+            received: 'Yes'
+          }
+        },
+        data: {
+          permittedDecreeNisiReason: '3'
+        }
+      }
+    };
+
+    it('renders the correct content', () => {
+      const specificContentToNotExist = ['dWAAppStatusMsgCoRespDetails'];
+
+      return content(PetitionProgressBar, session, { specificContentToNotExist });
+    });
+
+    it('renders the correct template', () => {
+      const instance = stepAsInstance(PetitionProgressBar, session);
+      expect(instance.stateTemplate).to.eql(templates.defendedWithoutAnswer);
+    });
+  });
+
+  describe('CCD state: DNawaiting, CoResp Not Replied DNReason : 3 ', () => {
+    const session = {
+      case: {
+        state: 'AwaitingDecreeNisi',
+        reasonForDivorce: 'adultery',
+        reasonForDivorceAdulteryWishToName: 'Yes',
+        coRespondentAnswers: {
+        },
+        data: {
+          permittedDecreeNisiReason: '3'
+        }
+      }
+    };
+
+    it('renders the correct content', () => {
+      const specificContent = ['dWAAppStatusMsgCoRespDetails'];
+
+      return content(PetitionProgressBar, session, { specificContent });
+    });
+
+    it('renders the correct template', () => {
+      const instance = stepAsInstance(PetitionProgressBar, session);
+      expect(instance.stateTemplate).to.eql(templates.defendedWithoutAnswer);
+    });
+  });
 
   describe('CCD state: DNawaiting, DNReason : 4 ', () => {
     const session = {


### PR DESCRIPTION
https://tools.hmcts.net/jira/browse/DIV-4395

In the case of Adultery
Respondent - Tried to defend the divorce but missed deadline to submit answer and the corespondent has not submitted their response the content on the DN status bar is changed to show CoResp has not replied
