### PR TITLE
DIV-4691 - Moved setting of CI env variable in Jenkinsfile

### DIFF
--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -38,12 +38,6 @@ withPipeline("nodejs", product, component) {
         slackSend(channel: '#div-dev', color: 'warning', message: "Yarn Audit has detected vulnerabilities in ${env.JOB_NAME}. You can check if there are patches for them in the full report, build details here: <${env.RUN_DISPLAY_URL}|Build ${env.BUILD_DISPLAY_NAME}>.")
       }
     }
-    // required for running functional tests on CI
-    env.FEATURE_IDAM = 'true'
-    env.IDAM_API_URL = 'https://idam-api.aat.platform.hmcts.net'
-    env.CASE_MAINTENANCE_BASE_URL = 'http://div-cms-aat.service.core-compute-aat.internal'
-    env.PREVIEW_ENV = 'true'
-    sh 'printenv'
   }
 
   before('securitychecks') {
@@ -54,6 +48,16 @@ withPipeline("nodejs", product, component) {
     stage('Test E2E') {
       sh 'yarn test:e2e'
     }
+  }
+
+  before('functionalTest:aks') {
+    env.NODE_ENV= 'ci'
+    sh 'printenv'
+  }
+
+  before('functionalTest:preview') {
+    env.NODE_ENV= 'ci'
+    sh 'printenv'
   }
 
   after('functionalTest:preview') {

--- a/Jenkinsfile_CNP
+++ b/Jenkinsfile_CNP
@@ -60,6 +60,11 @@ withPipeline("nodejs", product, component) {
     sh 'printenv'
   }
 
+  before('functionalTest:aat') {
+    env.NODE_ENV= 'ci'
+    sh 'printenv'
+  }
+
   after('functionalTest:preview') {
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**/*'
     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'

--- a/Jenkinsfile_parameterized
+++ b/Jenkinsfile_parameterized
@@ -30,7 +30,7 @@ static LinkedHashMap<String, Object> secret(String secretName, String envVar) {
 withParameterizedPipeline(params.TYPE, params.PRODUCT, params.COMPONENT, params.ENVIRONMENT, params.SUBSCRIPTION) {
   loadVaultSecrets(secrets)
   setVaultName('div')
-  
+
   after('test') {
     sh 'yarn test:validation'
     sh 'yarn test:e2e'
@@ -38,7 +38,7 @@ withParameterizedPipeline(params.TYPE, params.PRODUCT, params.COMPONENT, params.
 
   before('functionalTest:saat') {
     // required for running functional tests on CI
-    env.CASE_MAINTENANCE_BASE_URL = 'http://div-cms-saat.service.core-compute-saat.internal'
+    env.NODE_ENV= 'ci'
     sh 'printenv'
   }
 

--- a/config/ci.yml
+++ b/config/ci.yml
@@ -1,0 +1,9 @@
+
+services:
+  idam:
+    apiUrl: https://idam-api.aat.platform.hmcts.net
+  caseMaintenance:
+    baseUrl: http://div-cms-aat.service.core-compute-aat.internal
+
+features:
+  idam: true


### PR DESCRIPTION
# Description

The pipeline was recently changed where the `test` stage is skipped if you re-run a PR with no changes, meaning any setup done in the `after('test')"` step is done, causing tests to fail

* Moved ci-specific variables to the ci.yml
* Moved setting of NODE_ENV to before functional tests because the test
stage can now be skipped

![Screenshot 2019-04-11 at 10 37 35](https://user-images.githubusercontent.com/629600/55947171-e40bfb00-5c45-11e9-8807-6f99ee35e4fe.png)


Fixes #DIV-4691

Changed already applied in https://github.com/hmcts/div-respondent-frontend/pull/280

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
