### PR TITLE
DIV-4622 screen reader reads case reference ID as seperate characters

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,10 @@
   "engines": {
     "node": ">=8.9.4 <9.0.0"
   },
+  "jest": {
+    "verbose": true,
+    "testURL": "https://localhost:3000"
+  },
   "scripts": {
     "start": "NODE_PATH=. node server.js",
     "setup": "NODE_PATH=.",

--- a/steps/done/Done.html
+++ b/steps/done/Done.html
@@ -12,7 +12,7 @@
 
     <p class="text-reference">
       {{ content.referenceNumber }}<br>
-      <strong class="text-reference-number">{{ case.caseReference | safe }}</strong>
+      <strong class="text-reference-number" aria-label="{{ case.caseReference | a11yCharSeparator | safe }}">{{ case.caseReference | safe }}</strong>
     </p>
 
   </div>

--- a/test/unit/views/filters/a11y.test.js
+++ b/test/unit/views/filters/a11y.test.js
@@ -1,0 +1,34 @@
+const modulePath = '../../../../views/filters/a11y';
+
+const { expect } = require('@hmcts/one-per-page-test-suite');
+const filter = require(modulePath);
+
+describe(modulePath, () => {
+  describe('a11yCharSeparator', () => {
+    it('should return string formatted', () => {
+      const stringToFormat = 'ABC1234';
+      const stringFormatted = 'A B C 1 2 3 4';
+      expect(filter.a11yCharSeparator(stringToFormat)).to.eql(stringFormatted);
+    });
+    it('should return string formatted correctly when there is whitespace in the string', () => {
+      const stringToFormat = '  ABC1    234        ';
+      const stringFormatted = 'A B C 1 2 3 4';
+      expect(filter.a11yCharSeparator(stringToFormat)).to.eql(stringFormatted);
+    });
+    it('should handle an empty string', () => {
+      const stringToFormat = '';
+      const stringFormatted = '';
+      expect(filter.a11yCharSeparator(stringToFormat)).to.eql(stringFormatted);
+    });
+    it('should handle a null value', () => {
+      const stringToFormat = null;
+      const stringFormatted = null;
+      expect(filter.a11yCharSeparator(stringToFormat)).to.eql(stringFormatted);
+    });
+    it('should handle a number value', () => {
+      const stringToFormat = 1234;
+      const stringFormatted = 1234;
+      expect(filter.a11yCharSeparator(stringToFormat)).to.eql(stringFormatted);
+    });
+  });
+});

--- a/test/w3cjs/index.js
+++ b/test/w3cjs/index.js
@@ -16,7 +16,8 @@ const excludedWarnings = [
   'The “contentinfo” role is unnecessary for element “footer”.',
   'The “complementary” role is unnecessary for element “aside”.',
   'The “navigation” role is unnecessary for element “nav”.',
-  'The first occurrence of ID “dnCosts.claimCosts” was here.'
+  'The first occurrence of ID “dnCosts.claimCosts” was here.',
+  'Possible misuse of “aria-label”. (If you disagree with this warning, file an issue report or send e-mail to www-validator@w3.org.)' // eslint-disable-line max-len
 ];
 const filteredWarnings = r => {
   return !excludedWarnings.includes(r.message);

--- a/views/filters/a11y.js
+++ b/views/filters/a11y.js
@@ -1,0 +1,11 @@
+const a11yCharSeparator = input => {
+  if (typeof input === 'string') {
+    // Regex replace to remove all excess whitespace (e.g. '  a      b ' -> 'ab')
+    const returnString = input.replace(/\s+/g, '');
+    // split each character of the no whitespace string and join with 1 whitespace character
+    return returnString.split('').join(' ');
+  }
+  return input;
+};
+
+module.exports.a11yCharSeparator = a11yCharSeparator;


### PR DESCRIPTION
# Description

Previously when a screen reader would read the case reference Id it would ready numeric characters as numbers, e.g. an Id of `TOM123` would be read as `TOM one hundred and twenty three`, instead of `T O M one two three`. This change adds a nunjucks filter which spaces out each of the characters which is applied to an ARIA label, so that when a screen reader tries to read it out, the version that the screen reader reads will have a whitespace inbetween each character, causing it to read out each character indevidualy.

Fixes # (issue)
[Accessibility [AA] - Case ID Number](https://tools.hmcts.net/jira/browse/DIV-4622)

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Enable a screen reader and check output when on the case identification number.
Unit testing of new filter functionality.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
