### PR TITLE
DIV-5213: Redirect users from DN to correct pages

### DIFF
--- a/helpers/caseOrchestrationHelper.js
+++ b/helpers/caseOrchestrationHelper.js
@@ -3,7 +3,6 @@ const { get } = require('lodash');
 const config = require('config');
 const redirectToFrontendHelper = require('helpers/redirectToFrontendHelper');
 const { NOT_FOUND, MULTIPLE_CHOICES } = require('http-status-codes');
-const idamService = require('services/idam');
 
 const REDIRECT_TO_PETITIONER_FE = Symbol('redirect_to_pfe');
 const redirectToPetitionerError = new Error('No valid state or no court included');
@@ -89,9 +88,7 @@ const handleErrorCodes = (error, req, res, next) => {
     res.redirect(config.paths.contactDivorceTeamError);
     break;
   case REDIRECT_TO_RESPONDENT_FE:
-    idamService.logout()(req, res, () => {
-      redirectToFrontendHelper.redirectToAos(req, res);
-    });
+    redirectToFrontendHelper.redirectToAos(req, res);
     break;
   case REDIRECT_TO_DECREE_ABSOLUTE_FE:
     redirectToFrontendHelper.redirectToDa(req, res);

--- a/test/unit/helpers/caseOrchestrationHelper.test.js
+++ b/test/unit/helpers/caseOrchestrationHelper.test.js
@@ -10,7 +10,6 @@ const caseOrchestrationHelper = require(moduleName);
 const config = require('config');
 const redirectToFrontendHelper = require('helpers/redirectToFrontendHelper');
 const { NOT_FOUND, MULTIPLE_CHOICES, IM_A_TEAPOT } = require('http-status-codes');
-const idam = require('services/idam');
 
 describe(moduleName, () => {
   describe('#formatSessionForSubmit', () => {
@@ -197,12 +196,8 @@ describe(moduleName, () => {
     });
 
     it('redirect to respondent frontend & logouts out of idam if error is REDIRECT_TO_RESPONDENT_FE', () => {
-      const idamLogoutMiddleware = sinon.stub().callsArg(2);
-      sinon.stub(idam, 'logout').returns(idamLogoutMiddleware);
       caseOrchestrationHelper.handleErrorCodes(caseOrchestrationHelper.redirectToRespondentError);
       expect(redirectToFrontendHelper.redirectToAos.calledOnce).to.eql(true);
-      expect(idam.logout.calledOnce).to.eql(true);
-      idam.logout.restore();
     });
 
     it('redirect to decree absolute frontend if error is REDIRECT_TO_DECREE_ABSOLUTE_FE', () => {

--- a/test/unit/helpers/caseOrchestrationHelper.test.js
+++ b/test/unit/helpers/caseOrchestrationHelper.test.js
@@ -195,7 +195,7 @@ describe(moduleName, () => {
       expect(res.redirect.calledOnce).to.eql(true);
     });
 
-    it('redirect to respondent frontend & logouts out of idam if error is REDIRECT_TO_RESPONDENT_FE', () => {
+    it('redirect to respondent frontend if error is REDIRECT_TO_RESPONDENT_FE', () => {
       caseOrchestrationHelper.handleErrorCodes(caseOrchestrationHelper.redirectToRespondentError);
       expect(redirectToFrontendHelper.redirectToAos.calledOnce).to.eql(true);
     });


### PR DESCRIPTION
# Description

Log into DA and DN with RFE (AOS complete) credentials.

Expected Behaviour:
If Respondent tries to login to DN or DA, they should be redirected to the RFE

Actual Behaviour:
RFE are being sent to PFE application

Fixes # (issue)
https://tools.hmcts.net/jira/browse/DIV-5213

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
