### PR TITLE
Update to use the public HMCTS docker registry

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM hmcts.azurecr.io/hmcts/base/node/stretch-slim-lts-8 as base
+FROM hmctspublic.azurecr.io/base/node/stretch-slim-lts-8:8-stretch-slim as base
 USER root
 RUN apt-get update && apt-get install -y bzip2 git
 USER hmcts

--- a/acb.tpl.yaml
+++ b/acb.tpl.yaml
@@ -3,14 +3,14 @@ steps:
   # Pull previous build images
   # This is used to leverage on layers re-use for the next steps
   - id: pull-base
-    cmd: docker pull {{.Run.Registry}}/hmcts/div-decree-nisi-frontend/base:latest || true
+    cmd: docker pull {{.Run.Registry}}/div/decree-nisi-frontend/base:latest || true
     when: ["-"]
     keep: true
   # (Re)create base image
   - id: base
     build: >
-      -t {{.Run.Registry}}/hmcts/div-decree-nisi-frontend/base
-      --cache-from {{.Run.Registry}}/hmcts/div-decree-nisi-frontend/base:latest
+      -t {{.Run.Registry}}/div/decree-nisi-frontend/base
+      --cache-from {{.Run.Registry}}/div/decree-nisi-frontend/base:latest
       --target base
       .
     when:
@@ -20,7 +20,7 @@ steps:
   - id: runtime
     build: >
       -t {{.Run.Registry}}/{{CI_IMAGE_TAG}}
-      --cache-from {{.Run.Registry}}/hmcts/div-decree-nisi-frontend/base:latest
+      --cache-from {{.Run.Registry}}/div/decree-nisi-frontend/base:latest
       --target runtime
       .
     when:
@@ -29,7 +29,7 @@ steps:
   # Push to registry
   - id: push-images
     push:
-      - "{{.Run.Registry}}/hmcts/div-decree-nisi-frontend/base:latest"
+      - "{{.Run.Registry}}/div/decree-nisi-frontend/base:latest"
       - "{{.Run.Registry}}/{{CI_IMAGE_TAG}}"
     when:
       - runtime


### PR DESCRIPTION
# Description

> Next monday we will be changing the registry the pipeline will be pushing to by default
> the registry will be changing from:
> hmcts => hmctspublic
> you will no longer need to log in to pull your images (because it is a public registry, same as dockerhub)
> the name of the "repo" will change from
> "hmcts/product-component" => "product/component"


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)


# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [x] Any dependent changes have been merged and published in downstream modules
