### PR TITLE
Div 4677 table layout needed instead of dl layout

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
   "dependencies": {
     "@hmcts/div-document-express-handler": "^1.1.0",
     "@hmcts/div-idam-express-middleware": "^6.5.0",
-    "@hmcts/look-and-feel": "^3.0.2",
+    "@hmcts/look-and-feel": "^4.0.0",
     "@hmcts/node-js-environment-variable-setter": "https://github.com/hmcts/node-js-environment-variable-setter#0.2",
     "@hmcts/nodejs-healthcheck": "^1.5.1",
     "@hmcts/nodejs-logging": "^3.0.0",

--- a/steps/check-your-answers/CheckYourAnswers.content.json
+++ b/steps/check-your-answers/CheckYourAnswers.content.json
@@ -26,6 +26,6 @@
       }
     },
 
-    "summaryTableCaption": "This table has a list of your questions and answers. The first column is the question. The second column is your answer and the third column is a link to change your answer of that answericular question."
+    "summaryTableCaption": "This table has a list of your questions and answers. The first column is the question. The second column is your answer and the third column is a link to change your answer of that particular question."
   }
 }

--- a/steps/check-your-answers/CheckYourAnswers.content.json
+++ b/steps/check-your-answers/CheckYourAnswers.content.json
@@ -24,6 +24,8 @@
       "statementOfTruth": {
         "yes": "I confirm that:"
       }
-    }
+    },
+
+    "summaryTableCaption": "This table has a list of your questions and answers. The first column is the question. The second column is your answer and the third column is a link to change your answer of that answericular question."
   }
 }

--- a/steps/check-your-answers/CheckYourAnswers.html
+++ b/steps/check-your-answers/CheckYourAnswers.html
@@ -9,7 +9,8 @@
 {% set pageContent = {
   title: content.title,
   continue: content.continue,
-  sendApplication: content.submit
+  sendApplication: content.submit,
+  summaryTableCaption: content.summaryTableCaption
 } %}
 
 {% block statement_of_truth_content %}

--- a/views/check-your-answers.njk
+++ b/views/check-your-answers.njk
@@ -20,7 +20,7 @@
 
       <table class="govuk-table">
         <caption class="govuk-table__caption">
-          <span class="visuallyhidden">{{ pageContent.summaryTableCaption }}</span> 
+          <span class="govuk-visually-hidden">{{ pageContent.summaryTableCaption }}</span> 
         </caption>
         <tbody class="govuk-table__body">
           

--- a/views/check-your-answers.njk
+++ b/views/check-your-answers.njk
@@ -18,28 +18,31 @@
 
       {{ header(title, size=titleSize) }}
 
-      {% for section in _sections %}
+      <table class="govuk-table">
+        <caption class="govuk-table__caption">
+          <span class="visuallyhidden">{{ pageContent.summaryTableCaption }}</span> 
+        </caption>
+        <tbody class="govuk-table__body">
+          
+          {% for section in _sections %}
 
-        {% if section.atLeast1Completed %}
-          {% if section.title and _sections|length > 1 %}
-            {{ header(section.title, size='m') }}
-          {% endif %}
-
-          <dl class="govuk-summary-list">
-
-            {% for part in section.completedAnswers %}
-              {% if not part.hide %}
-                {% if part.html %}
-                  {{ part.html | safe }}
-                {% else %}
-                  {{ answer(part.question, part.answer, part.url, part.id) }}
-                {% endif %}
+            {% if section.atLeast1Completed %}
+              {% if section.title and _sections|length > 1 %}
+                {{ header(section.title, size='m') }}
               {% endif %}
-            {% endfor %}
-
-          </dl>
-        {% endif %}
-      {% endfor %}
+                {% for answerContent in section.completedAnswers %}
+                  {% if not answerContent.hide %}
+                    {% if answerContent.html %}
+                      {{ answerContent.html | safe }}
+                    {% else %}
+                      {{ answer(answerContent.question, answerContent.answer, answerContent.url, answerContent.id) }}
+                    {% endif %}
+                  {% endif %}
+                {% endfor %}
+            {% endif %}
+          {% endfor %}
+        </tbody>
+      </table>
 
       {% if incomplete %}
         {% block continue_application %}

--- a/yarn.lock
+++ b/yarn.lock
@@ -259,10 +259,42 @@
   resolved "https://registry.yarnpkg.com/@hmcts/eslint-config/-/eslint-config-1.4.0.tgz#e713457cee3758a43394c2974913885aaae8a41b"
   integrity sha1-5xNFfO43WKQzlMKXSROIWqropBs=
 
-"@hmcts/look-and-feel@^3.0.2", "@hmcts/look-and-feel@^3.0.3":
+"@hmcts/look-and-feel@^3.0.3":
   version "3.0.4"
   resolved "https://registry.yarnpkg.com/@hmcts/look-and-feel/-/look-and-feel-3.0.4.tgz#2eef24f78545a7d24b0a6de7192fd3b5ed398123"
   integrity sha512-opc4UlWbbOLt7VIRDBfxfgHWFL+WfQRPa8bernKK98ZP3l4DZszwQiesi2rbmYlv5PTsLEK5l0vACAeL35qFyg==
+  dependencies:
+    babel-core "^6.26.0"
+    babel-loader "^7.1.2"
+    babel-preset-env "^1.6.0"
+    check-types "^7.3.0"
+    colors "^1.1.2"
+    config "^1.26.1"
+    copy-webpack-plugin "^4.0.1"
+    css-loader "^3.0.0"
+    deepmerge "2.0.1"
+    diff-so-fancy "^1.1.1"
+    exports-loader "^0.7.0"
+    express "^4.15.3"
+    express-nunjucks "^2.2.3"
+    extract-text-webpack-plugin "^3.0.0"
+    govuk-frontend "^2.6.0"
+    hard-source-webpack-plugin "^0.13.1"
+    imports-loader "github:webpack-contrib/imports-loader#abea1c24f84b1343f9a277e33c8d89c83c013274"
+    jquery "^3.2.1"
+    js-yaml "^3.9.1"
+    node-sass "^4.12.0"
+    nunjucks "^3.1.7"
+    sass-loader "^6.0.6"
+    serve-static "^1.13.2"
+    style-loader "^0.20.1"
+    webpack "^3.4.1"
+    webpack-dev-middleware "^2.0.4"
+
+"@hmcts/look-and-feel@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@hmcts/look-and-feel/-/look-and-feel-4.0.0.tgz#59ca41a5e10f74f4be6fc1647f456758153e839e"
+  integrity sha512-7XJJZow/TKtO/N9pEWkl9Cklv7cmAWuLufP3zWjlvEYQqUT5MK9ITAjCHBNRqQQdv01sNlmTD7kSpSzQF22EZA==
   dependencies:
     babel-core "^6.26.0"
     babel-loader "^7.1.2"


### PR DESCRIPTION
# Description

Update look-and-feel framework version, to make use of the new html template for the 'check your answers' page. This change simply consists of converting the summary list from a 'dl' element to a 'table' element.
See: hmcts/look-and-feel#126

Fixes https://tools.hmcts.net/jira/browse/DIV-4677

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

No additional tests required.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
