### PR TITLE
retry request to validate html

### DIFF
--- a/test/w3cjs/index.js
+++ b/test/w3cjs/index.js
@@ -7,6 +7,9 @@ const cosMockCase = require('mocks/services/case-orchestration/retrieve-case/moc
 const config = require('config');
 const feesAndPaymentsService = require('services/feesAndPaymentsService');
 
+const maxHtmlValidationRetries = 3;
+const htmlValidationTimeout = 5000;
+
 
 // Ignored warnings
 const excludedWarnings = [
@@ -82,6 +85,44 @@ const w3cjsValidate = html => {
   });
 };
 
+const repeatW3cjsValidate = html => {
+  let retries = 0;
+
+  return new Promise((resolve, reject) => {
+    const doValidation = () => {
+      const promise = w3cjsValidate(html)
+        .then(results => {
+          if (!promise.done) {
+            resolve(results);
+          }
+          // set promise done so it does not resolve/reject after timeout
+          promise.done = true;
+        })
+        .catch(error => {
+          if (!promise.done) {
+            reject(error);
+          }
+          // set promise done so it does not resolve/reject after timeout
+          promise.done = true;
+        });
+
+      // catch timeouted request to w3jcs validate
+      setTimeout(() => {
+        retries = retries + 1;
+        if (!promise.done && retries < maxHtmlValidationRetries) {
+          doValidation();
+        } else {
+          reject(new Error('Unable to validate html'));
+        }
+        // set promise done so it does not resolve/reject after timeout
+        promise.done = true;
+      }, htmlValidationTimeout);
+    };
+
+    doValidation();
+  });
+};
+
 steps
   .filter(filterSteps)
   .forEach(step => {
@@ -89,7 +130,9 @@ steps
       let errors = [];
       let warnings = [];
 
-      before(() => {
+      before(function beforeTests() {
+        this.timeout(htmlValidationTimeout * maxHtmlValidationRetries);
+
         sinon.stub(feesAndPaymentsService, 'getFee')
           .resolves({
             feeCode: 'FEE0002',
@@ -99,7 +142,7 @@ steps
           });
 
         return stepHtml(step)
-          .then(html => w3cjsValidate(html))
+          .then(html => repeatW3cjsValidate(html))
           .then(results => {
             errors = results.errors;
             warnings = results.warnings;


### PR DESCRIPTION
# Description

our requests to validate html keep failing so this PR adds a temporary solution to retry the request up to three times if it fails