### PR TITLE
DIV-5229 - Respond to courts feedback - more information / upload docs page

### DIFF
--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -56,3 +56,8 @@ textarea.form-control {
   padding-left: 0;
   margin: 0;
 }
+
+.court-feedback{
+  border-color: $govuk-error-colour;
+  border-width: 7px;
+}

--- a/config/default.yml
+++ b/config/default.yml
@@ -106,6 +106,7 @@ paths:
   amendApplication: /amend-application
   respNotAdmitAdultery: /resp-does-not-admit-adultery-options
   reviewAosResponseFromCoRespondent: /review-aos-response-from-co-respondent
+  courtFeedback: /court-feedback
   mock:
     idamLogin: /idam-mock-login
     modifySession: /session
@@ -130,7 +131,7 @@ tests:
 
 features:
   idam: false
-  awaitingClarification: false
+  awaitingClarification: true
 
 journey:
   timeoutDelay: 300

--- a/mocks/services/case-orchestration/retrieve-case/mock-case.json
+++ b/mocks/services/case-orchestration/retrieve-case/mock-case.json
@@ -418,6 +418,15 @@
     ],
     "hearingDate": [
       "2022-04-25T00:00:00.000Z"
-    ]
+    ],
+    "RefusalClarificationReason": [
+      "jurisdictionDetails",
+      "marriageCertTranslation",
+      "marriageCertificate",
+      "previousProceedingDetails",
+      "caseDetailsStatement",
+      "other"
+    ],
+    "RefusalClarificationAdditionalInfo": "Extra details provided by the court"
   }
 }

--- a/steps/court-feedback/CourtFeedback.content.json
+++ b/steps/court-feedback/CourtFeedback.content.json
@@ -1,0 +1,42 @@
+{
+  "en": {
+    "title": "Respond to the court's feedback?",
+    "needToRespond": "You need to respond to the court's feedback before your application can proceed.",
+    "needToProvide" : "What you need to provide",
+    "feedback" : {
+      "jurisdictionDetails": {
+        "title": "Jurisdiction details",
+        "description": "The court has judged that your application does not fall within the jurisdiction of the courts of England and Wales. You must provide more connections to England or Wales."
+      },
+      "marriageCertTranslation": {
+        "title": "Marriage Certificate Translation",
+        "description": "The marriage certificate must be translated and certified by one of the following methods:",
+        "method1": "Statement of truth<br>The translator of the marriage certificate provides a statment of truth certifying the translation. There are translation services online which inlcude certification as part of their service.",
+        "method2": "Notary public<br>The marriage certificate is translated and then certified by a notary public. You can find a notary public through either the Notaries Society of the Society of Scrivener Notaries."
+      },
+      "marriageCertificate": {
+        "title": "Marriage Certificate",
+        "description": "TBC"
+      },
+      "previousProceedingDetails": {
+        "title": "Previous Proceeding Details",
+        "description": "TBC"
+      },
+      "caseDetailsStatement": {
+        "title": "Case Details Statement",
+        "description": "TBC"
+      },
+      "other": {
+        "title": "Further feedback provided by the court"
+      }
+    },
+    "errors": {
+      "required": "Enter your response"
+    },
+    "fields": {
+      "response": {
+        "title": "Your response"
+      }
+    }
+  }
+}

--- a/steps/court-feedback/CourtFeedback.html
+++ b/steps/court-feedback/CourtFeedback.html
@@ -1,0 +1,44 @@
+{% extends "question.njk" %}
+
+{% from "look-and-feel/components/fields.njk" import textarea %}
+
+{% set title %}
+  {{ content.title | safe }}
+{% endset %}
+
+{% block fields %}
+
+  <p class="govuk-body">{{ content.needToRespond | safe }}</p>
+
+  <h2 class="govuk-heading-m">{{ content.needToProvide }}</h2>
+
+  {% for feedback in feedbacks %}
+
+    <div class="govuk-inset-text court-feedback">
+
+      <h3 class="govuk-heading-s">{{ content.feedback[feedback].title }}</h3>
+      {% if feedback != "other" %}
+        <p class="govuk-body">{{ content.feedback[feedback].description }}</p>
+      {% endif %}
+
+      {% if feedback == "marriageCertTranslation" %}
+        <ul class="govuk-list govuk-list--number">
+          <li>{{ content.feedback[feedback].method1 | safe }}</li>
+          <li>{{ content.feedback[feedback].method2 | safe }}</li>
+        </ul>
+      {% endif %}
+
+      {% if feedback == "other" %}
+        <p class="govuk-body">{{ case.RefusalClarificationAdditionalInfo }}</p>
+      {% endif %}
+
+    </div>
+
+  {% endfor %}
+
+  {{ textarea(
+    fields.response,
+    content.fields.response.title
+  ) }}
+
+{% endblock %}

--- a/steps/court-feedback/CourtFeedback.step.js
+++ b/steps/court-feedback/CourtFeedback.step.js
@@ -1,0 +1,41 @@
+/* eslint-disable max-len */
+const { Question } = require('@hmcts/one-per-page/steps');
+const { redirectTo } = require('@hmcts/one-per-page/flow');
+const config = require('config');
+const idam = require('services/idam');
+const Joi = require('joi');
+
+const { form, text } = require('@hmcts/one-per-page/forms');
+
+class CourtFeedback extends Question {
+  static get path() {
+    return config.paths.courtFeedback;
+  }
+
+  get case() {
+    return this.req.session.case.data;
+  }
+
+  get feedbacks() {
+    return this.case.RefusalClarificationReason;
+  }
+
+  get form() {
+    const validate = Joi.string()
+      .required();
+
+    const response = text.joi(this.content.errors.required, validate);
+
+    return form({ response });
+  }
+
+  next() {
+    return redirectTo(this.journey.steps.ShareCourtDocuments);
+  }
+
+  get middleware() {
+    return [...super.middleware, idam.protect()];
+  }
+}
+
+module.exports = CourtFeedback;

--- a/steps/petition-progress-bar/PetitionProgressBar.step.js
+++ b/steps/petition-progress-bar/PetitionProgressBar.step.js
@@ -23,6 +23,7 @@ const constants = {
   NotDefined: 'notdefined',
   DNAwaiting: 'awaitingdecreenisi',
   awaitingPronouncement: 'awaitingpronouncement',
+  awaitingClarification: 'awaitingclarification',
   undefendedReason: '0',
   no: 'no',
   yes: 'yes'
@@ -79,6 +80,10 @@ class PetitionProgressBar extends Interstitial {
     return this.req.session.case.state ? this.req.session.case.state.toLowerCase() : constants.NotDefined;
   }
 
+  get showCourtFeedback() {
+    return this.caseState === constants.awaitingClarification && config.features.awaitingClarification;
+  }
+
   get showDnNoResponse() {
     return this.caseState === constants.AOSOverdue;
   }
@@ -121,6 +126,8 @@ class PetitionProgressBar extends Interstitial {
 
   next() {
     return branch(
+      redirectTo(this.journey.steps.CourtFeedback)
+        .if(this.showCourtFeedback),
       redirectTo(this.journey.steps.DnNoResponse)
         .if(this.showDnNoResponse),
       redirectTo(this.journey.steps.ReviewAosResponse)

--- a/test/e2e/journeys/ccdStates/awaitingClarification.test.js
+++ b/test/e2e/journeys/ccdStates/awaitingClarification.test.js
@@ -8,6 +8,10 @@ const Start = require('steps/start/Start.step');
 const IdamLogin = require('mocks/steps/idamLogin/IdamLogin.step');
 const petitionProgressBar = require('steps/petition-progress-bar/PetitionProgressBar.step');
 const Entry = require('steps/entry/Entry.step');
+const ShareCourtDocuments = require('steps/share-court-documents/ShareCourtDocuments.step');
+const CheckYourAnswers = require('steps/check-your-answers/CheckYourAnswers.step');
+const Done = require('steps/done/Done.step');
+const CourtFeedback = require('steps/court-feedback/CourtFeedback.step');
 
 const feesAndPaymentsService = require('services/feesAndPaymentsService');
 
@@ -15,8 +19,15 @@ const session = {
   respDefendsDivorce: null
 };
 
-describe('Case State :  AwaitingClarification', () => {
+let sandbox = {};
+
+describe('Case State: AwaitingClarification - feature AwaitingClarification is off', () => {
   before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(config, 'features').value({
+      awaitingClarification: false
+    });
+
     const getStub = sinon.stub(request, 'get');
     getStub
       .withArgs(sinon.match({
@@ -39,6 +50,7 @@ describe('Case State :  AwaitingClarification', () => {
   after(() => {
     request.get.restore();
     feesAndPaymentsService.getFee.restore();
+    sandbox.restore();
   });
 
   journey.test([
@@ -46,5 +58,49 @@ describe('Case State :  AwaitingClarification', () => {
     { step: IdamLogin, body: { success: 'yes' } },
     { step: Entry },
     { step: petitionProgressBar }
+  ]);
+});
+
+describe('Case State: AwaitingClarification - feature AwaitingClarification is on', () => {
+  before(() => {
+    sandbox = sinon.createSandbox();
+    sandbox.stub(config, 'features').value({
+      awaitingClarification: true
+    });
+
+    const getStub = sinon.stub(request, 'get');
+    getStub
+      .withArgs(sinon.match({
+        uri: `${config.services.orchestrationService.getCaseUrl}`
+      }))
+      .resolves(merge({}, mockCaseResponse, {
+        state: 'AwaitingClarification',
+        data: session
+      }));
+
+    sinon.stub(feesAndPaymentsService, 'getFee')
+      .resolves({
+        feeCode: 'FEE0002',
+        version: 4,
+        amount: 550.00,
+        description: 'Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2.' // eslint-disable-line max-len
+      });
+  });
+
+  after(() => {
+    request.get.restore();
+    feesAndPaymentsService.getFee.restore();
+    sandbox.restore();
+  });
+
+  journey.test([
+    { step: Start },
+    { step: IdamLogin, body: { success: 'yes' } },
+    { step: Entry },
+    { step: petitionProgressBar },
+    { step: CourtFeedback, body: { response: 'some details' } },
+    { step: ShareCourtDocuments, body: { upload: 'no' } },
+    { step: CheckYourAnswers, body: { statementOfTruth: 'yes' } },
+    { step: Done }
   ]);
 });

--- a/test/functional/pages/courtFeedback.js
+++ b/test/functional/pages/courtFeedback.js
@@ -1,0 +1,15 @@
+const CourtFeedback = require('steps/court-feedback/CourtFeedback.step');
+const ShareCourtDocuments = require('steps/share-court-documents/ShareCourtDocuments.step');
+const commonContent = require('common/content');
+
+function testCourtFeedback() {
+  const I = this;
+
+  I.amOnLoadedPage(CourtFeedback.path);
+  I.fillField('response', 'some details...');
+  I.navByClick(commonContent.en.continue);
+
+  I.seeCurrentUrlEquals(ShareCourtDocuments.path);
+}
+
+module.exports = { testCourtFeedback };

--- a/test/functional/paths/pages.js
+++ b/test/functional/paths/pages.js
@@ -49,6 +49,8 @@ Scenario('Pages', async I => {
 
   I.testDesertionAskedToResumeDN();
 
+  I.testCourtFeedback();
+
   I.testCheckYourAnswersPage();
 
   I.testDonePage();

--- a/test/unit/steps/courtFeedback.test.js
+++ b/test/unit/steps/courtFeedback.test.js
@@ -1,0 +1,100 @@
+const modulePath = 'steps/court-feedback/CourtFeedback.step';
+
+const CourtFeedback = require(modulePath);
+const { content, sinon, middleware, question } = require('@hmcts/one-per-page-test-suite');
+const idam = require('services/idam');
+const ShareCourtDocuments = require('steps/share-court-documents/ShareCourtDocuments.step');
+
+describe(modulePath, () => {
+  beforeEach(() => {
+    sinon.stub(idam, 'protect').returns(middleware.nextMock);
+  });
+
+  afterEach(() => {
+    idam.protect.restore();
+  });
+
+  describe('content', () => {
+    it('renders the base content', () => {
+      const session = { case: { data: {} } };
+      const specificContent = [
+        'title',
+        'needToRespond',
+        'needToProvide'
+      ];
+      return content(CourtFeedback, session, { specificContent });
+    });
+
+    it('feedback for jurisdictionDetails', () => {
+      const session = { case: { data: { RefusalClarificationReason: ['jurisdictionDetails'] } } };
+      const specificContent = [
+        'feedback.jurisdictionDetails.title',
+        'feedback.jurisdictionDetails.description'
+      ];
+      return content(CourtFeedback, session, { specificContent });
+    });
+
+    it('feedback for marriageCertTranslation', () => {
+      const session = { case: { data: {
+        RefusalClarificationReason: ['marriageCertTranslation']
+      } } };
+      const specificContent = [
+        'feedback.marriageCertTranslation.title',
+        'feedback.marriageCertTranslation.description',
+        'feedback.marriageCertTranslation.method1',
+        'feedback.marriageCertTranslation.method2'
+      ];
+      return content(CourtFeedback, session, { specificContent });
+    });
+
+    it('feedback for marriageCertificate', () => {
+      const session = { case: { data: { RefusalClarificationReason: ['marriageCertificate'] } } };
+      const specificContent = [
+        'feedback.marriageCertificate.title',
+        'feedback.marriageCertificate.description'
+      ];
+      return content(CourtFeedback, session, { specificContent });
+    });
+
+    it('feedback for previousProceedingDetails', () => {
+      const session = { case: { data: {
+        RefusalClarificationReason: ['previousProceedingDetails']
+      } } };
+      const specificContent = [
+        'feedback.previousProceedingDetails.title',
+        'feedback.previousProceedingDetails.description'
+      ];
+      return content(CourtFeedback, session, { specificContent });
+    });
+
+    it('feedback for caseDetailsStatement', () => {
+      const session = { case: { data: { RefusalClarificationReason: ['caseDetailsStatement'] } } };
+      const specificContent = [
+        'feedback.caseDetailsStatement.title',
+        'feedback.caseDetailsStatement.description'
+      ];
+      return content(CourtFeedback, session, { specificContent });
+    });
+
+    it('feedback for other', () => {
+      const session = { case: { data: {
+        RefusalClarificationReason: ['other'],
+        RefusalClarificationAdditionalInfo: 'some extra info'
+      } } };
+      const specificContent = [ 'feedback.other.title' ];
+      const specificValues = [ 'some extra info' ];
+      return content(CourtFeedback, session, { specificContent, specificValues });
+    });
+  });
+
+  it('shows error if response not answered', () => {
+    const session = { case: { data: { } } };
+    return question.testErrors(CourtFeedback, session);
+  });
+
+  it('redirects to the ShareCourtDocuments page', () => {
+    const fields = { response: 'some details' };
+    const session = { case: { data: { } } };
+    return question.redirectWithField(CourtFeedback, fields, ShareCourtDocuments, session);
+  });
+});


### PR DESCRIPTION
# Description

[DIV-5229 - Respond to courts feedback - more information / upload docs page](https://tools.hmcts.net/jira/browse/DIV-5229)
 - Added new page that allows response to court feedback
 - Updated flow so that the next question asks for uploading documents

**Todo**
1. Missing content for Marriage Certificate, Previous Proceeding Details, Case Details Statement
2. ccd field for petitioner response field
3. submission endpoint ( could be the same as normal in that case nothing needs to change )
4. Check your answers page content for response is currently the content provided by court. is this right? probably should be something like "You're response"?