### PR TITLE
Awaiting Clarification Journey

### DIFF
--- a/assets/images/drag-drop-upload-hover-ico.svg
+++ b/assets/images/drag-drop-upload-hover-ico.svg
@@ -1,15 +1,23 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="90px" height="90px" viewBox="0 0 90 90" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
-    <!-- Generator: Sketch 3.3.3 (12081) - http://www.bohemiancoding.com/sketch -->
-    <title>Oval 6 + Imported Layers</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Main-flow" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
-        <g id="New-claim---Long-form" sketch:type="MSArtboardGroup" transform="translate(-406.000000, -4133.000000)">
-            <g id="Oval-6-+-Imported-Layers" sketch:type="MSLayerGroup" transform="translate(406.000000, 4133.000000)">
-                <circle id="Oval-6" fill="#FFBF47" sketch:type="MSShapeGroup" cx="45" cy="45" r="45"></circle>
-                <path d="M42.7952171,24.1136797 L42.7952171,59.6159104 L31.9269178,48.599282 C30.7704603,47.4271852 28.8937179,47.4271852 27.7359265,48.599282 C26.579469,49.7727307 26.579469,51.6735013 27.7372604,52.8455981 L45.7577224,71.1111111 L63.7795182,52.8455981 C64.35708,52.2602256 64.6465279,51.4923467 64.6465279,50.7217641 C64.6465279,49.9552371 64.35708,49.1846544 63.7795182,48.599282 C62.6217269,47.4271852 60.7463183,47.4271852 59.5898608,48.599282 L48.7215615,59.6159104 L48.7215615,24.1136797 C48.7215615,22.4548991 47.3943698,21.1111111 45.7577224,21.1111111 C44.1210749,21.1111111 42.7952171,22.4548991 42.7952171,24.1136797" id="Imported-Layers" fill="#FFFFFF" sketch:type="MSShapeGroup"></path>
-            </g>
-        </g>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 90 90"
+	 style="enable-background:new 0 0 90 90;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#FFBF47;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+</style>
+<title>Oval 6 + Imported Layers</title>
+<desc>Created with Sketch.</desc>
+<g id="Main-flow" sketch:type="MSPage">
+	<g id="New-claim---Long-form" transform="translate(-406.000000, -4133.000000)" sketch:type="MSArtboardGroup">
+		<g transform="translate(406.000000, 4133.000000)" sketch:type="MSLayerGroup">
+			<circle id="Oval-6" sketch:type="MSShapeGroup" class="st0" cx="45" cy="45" r="45">
+			</circle>
+			<path id="Imported-Layers" sketch:type="MSShapeGroup" class="st1" d="M47.2,65.9V30.4l10.9,11c1.2,1.2,3,1.2,4.2,0
+				c1.2-1.2,1.2-3.1,0-4.2l-18-18.3l-18,18.3c-0.6,0.6-0.9,1.4-0.9,2.1c0,0.8,0.3,1.5,0.9,2.1c1.2,1.2,3,1.2,4.2,0l10.9-11v35.5
+				c0,1.7,1.3,3,3,3C45.9,68.9,47.2,67.5,47.2,65.9"/>
+		</g>
+	</g>
+</g>
 </svg>

--- a/assets/images/drag-drop-upload-ico.svg
+++ b/assets/images/drag-drop-upload-ico.svg
@@ -1,15 +1,23 @@
-<?xml version="1.0" encoding="UTF-8" standalone="no"?>
-<svg width="90px" height="90px" viewBox="0 0 90 90" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns">
-    <!-- Generator: Sketch 3.3.3 (12081) - http://www.bohemiancoding.com/sketch -->
-    <title>Oval 6 + Imported Layers</title>
-    <desc>Created with Sketch.</desc>
-    <defs></defs>
-    <g id="Main-flow" stroke="none" stroke-width="1" fill="none" fill-rule="evenodd" sketch:type="MSPage">
-        <g id="New-claim---Long-form" sketch:type="MSArtboardGroup" transform="translate(-406.000000, -4133.000000)">
-            <g id="Oval-6-+-Imported-Layers" sketch:type="MSLayerGroup" transform="translate(406.000000, 4133.000000)">
-                <circle id="Oval-6" fill="#BFC1C3" sketch:type="MSShapeGroup" cx="45" cy="45" r="45"></circle>
-                <path d="M42.7952171,24.1136797 L42.7952171,59.6159104 L31.9269178,48.599282 C30.7704603,47.4271852 28.8937179,47.4271852 27.7359265,48.599282 C26.579469,49.7727307 26.579469,51.6735013 27.7372604,52.8455981 L45.7577224,71.1111111 L63.7795182,52.8455981 C64.35708,52.2602256 64.6465279,51.4923467 64.6465279,50.7217641 C64.6465279,49.9552371 64.35708,49.1846544 63.7795182,48.599282 C62.6217269,47.4271852 60.7463183,47.4271852 59.5898608,48.599282 L48.7215615,59.6159104 L48.7215615,24.1136797 C48.7215615,22.4548991 47.3943698,21.1111111 45.7577224,21.1111111 C44.1210749,21.1111111 42.7952171,22.4548991 42.7952171,24.1136797" id="Imported-Layers" fill="#FFFFFF" sketch:type="MSShapeGroup"></path>
-            </g>
-        </g>
-    </g>
+<?xml version="1.0" encoding="utf-8"?>
+<!-- Generator: Adobe Illustrator 23.0.1, SVG Export Plug-In . SVG Version: 6.00 Build 0)  -->
+<svg version="1.1" id="Layer_1" xmlns:sketch="http://www.bohemiancoding.com/sketch/ns"
+	 xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink" x="0px" y="0px" viewBox="0 0 90 90"
+	 style="enable-background:new 0 0 90 90;" xml:space="preserve">
+<style type="text/css">
+	.st0{fill-rule:evenodd;clip-rule:evenodd;fill:#BFC1C3;}
+	.st1{fill-rule:evenodd;clip-rule:evenodd;fill:#FFFFFF;}
+</style>
+<title>Oval 6 + Imported Layers</title>
+<desc>Created with Sketch.</desc>
+<g id="Main-flow" sketch:type="MSPage">
+	<g id="New-claim---Long-form" transform="translate(-406.000000, -4133.000000)" sketch:type="MSArtboardGroup">
+		<g transform="translate(406.000000, 4133.000000)" sketch:type="MSLayerGroup">
+			<circle id="Oval-6" sketch:type="MSShapeGroup" class="st0" cx="45" cy="45" r="45">
+			</circle>
+			<path id="Imported-Layers" sketch:type="MSShapeGroup" class="st1" d="M47.2,65.9V30.4l10.9,11c1.2,1.2,3,1.2,4.2,0
+				c1.2-1.2,1.2-3.1,0-4.2l-18-18.3l-18,18.3c-0.6,0.6-0.9,1.4-0.9,2.1c0,0.8,0.3,1.5,0.9,2.1c1.2,1.2,3,1.2,4.2,0l10.9-11v35.5
+				c0,1.7,1.3,3,3,3C45.9,68.9,47.2,67.5,47.2,65.9"/>
+		</g>
+	</g>
+</g>
 </svg>

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -56,3 +56,8 @@ textarea.form-control {
   padding-left: 0;
   margin: 0;
 }
+
+.court-feedback{
+  border-color: $govuk-error-colour;
+  border-width: 7px;
+}

--- a/assets/scss/main.scss
+++ b/assets/scss/main.scss
@@ -57,7 +57,7 @@ textarea.form-control {
   margin: 0;
 }
 
-.court-feedback{
+.court-feedback {
   border-color: $govuk-error-colour;
   border-width: 7px;
 }

--- a/common/constants.js
+++ b/common/constants.js
@@ -1,0 +1,6 @@
+const constants = {
+  notDefined: 'notdefined',
+  awaitingClarification: 'awaitingclarification'
+};
+
+module.exports = constants;

--- a/common/content.json
+++ b/common/content.json
@@ -41,7 +41,7 @@
         "description": "Clarify your evidence for the chosen reason (legally known as the 'facts') for your divorce."
       },
       "other": {
-        "title": "Further feedback provided by the court"
+        "title": "Additional comments"
       }
     }
   }

--- a/common/content.json
+++ b/common/content.json
@@ -16,6 +16,33 @@
     "allAgentsBusy": "All our web chat agents are busy helping other people. Please try again later or contact us using one of the ways above.",
     "chatClosed": "Web chat is now closed.\\nOpening hours are Monday to Friday, 9:30am to 5pm.",
     "chatAlreadyOpen": "A web chat window is already open.",
-    "chatOpeningHours": "Monday to Friday, 9:30am to 5pm."
+    "chatOpeningHours": "Monday to Friday, 9:30am to 5pm.",
+    "clarificationCourtFeedback" : {
+      "jurisdictionDetails": {
+        "title": "Jurisdiction details",
+        "description": "The court has judged that your application does not fall within the jurisdiction of the courts of England and Wales. You must provide more connections to England or Wales."
+      },
+      "marriageCertTranslation": {
+        "title": "Marriage Certificate Translation",
+        "description": "The marriage certificate must be translated and certified by one of the following methods:",
+        "method1": "Statement of truth<br>The translator of the marriage certificate provides a statment of truth certifying the translation. There are translation services online which inlcude certification as part of their service.",
+        "method2": "Notary public<br>The marriage certificate is translated and then certified by a notary public. You can find a notary public through either the Notaries Society of the Society of Scrivener Notaries."
+      },
+      "marriageCertificate": {
+        "title": "Your original marriage certificate",
+        "description": "The image of the marriage certificate you shared does not appear to be a scanned copy of the full original. Please provide a digital photo or scan of the original, or the paper document in the post."
+      },
+      "previousProceedingDetails": {
+        "title": "Previous Proceeding Details",
+        "description": "Clarify whether there are, or have ever been, any other legal proceedings related to the marriage, property or children."
+      },
+      "caseDetailsStatement": {
+        "title": "Case Details Statement",
+        "description": "Clarify your evidence for the chosen reason (legally known as the 'facts') for your divorce."
+      },
+      "other": {
+        "title": "Further feedback provided by the court"
+      }
+    }
   }
 }

--- a/common/content.json
+++ b/common/content.json
@@ -20,7 +20,14 @@
     "clarificationCourtFeedback" : {
       "jurisdictionDetails": {
         "title": "Jurisdiction details",
-        "description": "The court has judged that your application does not fall within the jurisdiction of the courts of England and Wales. You must provide more connections to England or Wales."
+        "description": "The court has judged that your application does not fall within the jurisdiction of the courts of England and Wales.<br><br>You must have at least one of the following legal connections for your divorce to fall within the jurisdiction of a court in England and Wales:",
+        "reason0": "My {{ case.divorceWho }} and I are both habitually resident in England or Wales",
+        "reason1": "My {{ case.divorceWho }} and I were last habitually resident in England or Wales and I still live there",
+        "reason2": "My {{ case.divorceWho }} is habitually resident in England or Wales",
+        "reason3": "I'm habitually resident in England or Wales and have lived here for at least a year",
+        "reason4": "I'm domiciled and habitually resident in England or Wales and have lived here for at least six months",
+        "reason5": "My {{ case.divorceWho }} and I are both domiciled in England or Wales",
+        "reason6": "I believe the courts of England and Wales have jurisdiction on a residual basis"
       },
       "marriageCertTranslation": {
         "title": "Marriage Certificate Translation",
@@ -30,7 +37,7 @@
       },
       "marriageCertificate": {
         "title": "Your original marriage certificate",
-        "description": "The image of the marriage certificate you shared does not appear to be a scanned copy of the full original. Please provide a digital photo or scan of the original, or the paper document in the post."
+        "description": "The image of the marriage certificate you shared does not appear to be a scanned copy of the full original. Please provide a digital photo or scan of the original, or the paper document in the post.<br><br>The image must be of the whole document and include the serial / system number and must be readable by court staff."
       },
       "previousProceedingDetails": {
         "title": "Previous Proceeding Details",

--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -88,7 +88,7 @@ journey:
 features:
   idam: FEATURE_IDAM
   webchat: FEATURE_WEBCHAT
-  awaitingClarificationNew: FEATURE_AWAITING_CLARIFICATION
+  awaitingClarification: FEATURE_AWAITING_CLARIFICATION
 
 ccd:
   courts: CCD_DIGITAL_COURTS

--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -88,6 +88,7 @@ journey:
 features:
   idam: FEATURE_IDAM
   webchat: FEATURE_WEBCHAT
+  awaitingClarificationNew: FEATURE_AWAITING_CLARIFICATION
 
 ccd:
   courts: CCD_DIGITAL_COURTS

--- a/config/default.yml
+++ b/config/default.yml
@@ -156,7 +156,7 @@ document:
   - 'costsOrder'
   - 'decreeNisi'
   - 'dnAnswers'
-  - 'refusalOrder'
+  - 'decreeNisiRefusalOrder'
 
 ccd:
   d8States:

--- a/config/default.yml
+++ b/config/default.yml
@@ -113,6 +113,7 @@ paths:
   respNotAdmitAdultery: /resp-does-not-admit-adultery-options
   reviewAosResponseFromCoRespondent: /review-aos-response-from-co-respondent
   accessibilityStatement: /accessibility-statement
+  courtFeedback: /court-feedback
   mock:
     idamLogin: /idam-mock-login
     modifySession: /session
@@ -138,6 +139,7 @@ tests:
 features:
   idam: false
   webchat: false
+  awaitingClarification: false
 
 journey:
   timeoutDelay: 300
@@ -154,6 +156,7 @@ document:
   - 'costsOrder'
   - 'decreeNisi'
   - 'dnAnswers'
+  - 'refusalOrder'
 
 ccd:
   d8States:

--- a/config/default.yml
+++ b/config/default.yml
@@ -156,7 +156,8 @@ document:
   - 'costsOrder'
   - 'decreeNisi'
   - 'dnAnswers'
-  - 'decreeNisiRefusalOrder'
+  - 'decreeNisiRefusalOrderClarification'
+  - 'decreeNisiRefusalOrderRejection'
 
 ccd:
   d8States:

--- a/infrastructure/main.tf
+++ b/infrastructure/main.tf
@@ -125,6 +125,7 @@ module "frontend" {
     // Feature toggling through config
     FEATURE_IDAM                            = "${var.feature_idam}"
     FEATURE_WEBCHAT                         = "${var.feature_webchat}"
+    FEATURE_AWAITING_CLARIFICATION          = "${var.awaiting_clarification}"
 
     // Encryption secrets
     SESSION_SECRET = "${data.azurerm_key_vault_secret.session_secret.value}"

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -201,6 +201,10 @@ variable "feature_idam" {
   default = true
 }
 
+variable "awaiting_clarification" {
+  default = false
+}
+
 variable "ccd_digital_courts" {
   type = "string"
   default = "[\"serviceCentre\"]"

--- a/mocks/services/case-orchestration/retrieve-case/mock-case.json
+++ b/mocks/services/case-orchestration/retrieve-case/mock-case.json
@@ -438,6 +438,7 @@
       "caseDetailsStatement",
       "other"
     ],
-    "refusalClarificationAdditionalInfo": "Extra details provided by the court"
+    "refusalClarificationAdditionalInfo": "Extra details provided by the court",
+    "dnOutcomeCase": "true"
   }
 }

--- a/mocks/services/case-orchestration/retrieve-case/mock-case.json
+++ b/mocks/services/case-orchestration/retrieve-case/mock-case.json
@@ -419,7 +419,7 @@
     "hearingDate": [
       "2022-04-25T00:00:00.000Z"
     ],
-    "RefusalClarificationReason": [
+    "refusalClarificationReason": [
       "jurisdictionDetails",
       "marriageCertTranslation",
       "marriageCertificate",
@@ -427,6 +427,6 @@
       "caseDetailsStatement",
       "other"
     ],
-    "RefusalClarificationAdditionalInfo": "Extra details provided by the court"
+    "refusalClarificationAdditionalInfo": "Extra details provided by the court"
   }
 }

--- a/mocks/services/case-orchestration/retrieve-case/mock-case.json
+++ b/mocks/services/case-orchestration/retrieve-case/mock-case.json
@@ -403,10 +403,30 @@
         "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/23e0b759-77b5-4778-a604-580f9c485238",
         "mimeType": null,
         "status": null
+      },
+      {
+        "id": "23e0b759-77b5-4778-a604-1234",
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "refusalOrder1559143445687032.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/23e0b759-77b5-4778-a604-1234",
+        "mimeType": null,
+        "status": null
       }
     ],
     "hearingDate": [
       "2022-04-25T00:00:00.000Z"
-    ]
+    ],
+    "RefusalClarificationReason": [
+      "jurisdictionDetails",
+      "marriageCertTranslation",
+      "marriageCertificate",
+      "previousProceedingDetails",
+      "caseDetailsStatement",
+      "other"
+    ],
+    "RefusalClarificationAdditionalInfo": "Extra details provided by the court"
   }
 }

--- a/mocks/services/case-orchestration/retrieve-case/mock-case.json
+++ b/mocks/services/case-orchestration/retrieve-case/mock-case.json
@@ -410,7 +410,7 @@
         "createdOn": null,
         "lastModifiedBy": 0,
         "modifiedOn": null,
-        "fileName": "refusalOrder1559143445687032.pdf",
+        "fileName": "decreeNisiRefusalOrder1559143445687032.pdf",
         "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/23e0b759-77b5-4778-a604-1234",
         "mimeType": null,
         "status": null

--- a/mocks/services/case-orchestration/retrieve-case/mock-case.json
+++ b/mocks/services/case-orchestration/retrieve-case/mock-case.json
@@ -410,7 +410,18 @@
         "createdOn": null,
         "lastModifiedBy": 0,
         "modifiedOn": null,
-        "fileName": "decreeNisiRefusalOrder1559143445687032.pdf",
+        "fileName": "decreeNisiRefusalOrderClarification1559143445687032.pdf",
+        "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/23e0b759-77b5-4778-a604-1234",
+        "mimeType": null,
+        "status": null
+      },
+      {
+        "id": "23e0b759-77b5-4778-a604-1234",
+        "createdBy": 0,
+        "createdOn": null,
+        "lastModifiedBy": 0,
+        "modifiedOn": null,
+        "fileName": "decreeNisiRefusalOrderRejection1559143445687032.pdf",
         "fileUrl": "http://dm-store-aat.service.core-compute-aat.internal/documents/23e0b759-77b5-4778-a604-1234",
         "mimeType": null,
         "status": null

--- a/mocks/steps/modify-session/ModifySession.step.js
+++ b/mocks/steps/modify-session/ModifySession.step.js
@@ -1,6 +1,6 @@
 const { Question } = require('@hmcts/one-per-page');
 const config = require('config');
-const { form, text } = require('@hmcts/one-per-page/forms');
+const { form, text, list } = require('@hmcts/one-per-page/forms');
 const path = require('path');
 const express = require('express');
 
@@ -67,6 +67,9 @@ class ModifySession extends Question {
     const respCostsReason = text;
     const reasonForDivorceAdulteryDetails = text;
 
+    const refusalClarificationReason = list(text);
+    const refusalClarificationAdditionalInfo = text;
+
     return form({
       divorceWho,
       reasonForDivorce,
@@ -90,7 +93,9 @@ class ModifySession extends Question {
       respJurisdictionRespCountryOfResidence,
       respLegalProceedingsDescription,
       respCostsReason,
-      reasonForDivorceAdulteryDetails
+      reasonForDivorceAdulteryDetails,
+      refusalClarificationReason,
+      refusalClarificationAdditionalInfo
     });
   }
 

--- a/mocks/steps/modify-session/sections/caseState.html
+++ b/mocks/steps/modify-session/sections/caseState.html
@@ -12,7 +12,7 @@
       { label: "AosSubmittedAwaitingAnswer", value: "AosSubmittedAwaitingAnswer" },
       { label: "AwaitingConsideration", value: "AwaitingConsideration" },
       { label: "AwaitingPronouncement", value: "AwaitingPronouncement" },
-      { label: "AwaitingClarification", value: "AwaitingClarification" },
+      { label: "AwaitingClarification", value: "AwaitingClarification", target: "awaiting-clarification-options" },
       { label: "AwaitingDecreeAbsolute", value: "AwaitingDecreeAbsolute" },
       { label: "DNPronounced", value: "DNPronounced" }
     ],
@@ -32,5 +32,32 @@
   hideQuestion = false,
   inline = true
 ) }}
+</div>
+
+<div class="js-hidden" id="awaiting-clarification-options">
+  {{ selectionButtons(fields.refusalClarificationReason, "Reason for clarification?",
+  options = [
+      { label: "Jurisdiction Details", value: "jurisdictionDetails" },
+      { label: "Marriage Certificatie Translation", value: "marriageCertTranslation" },
+      { label: "Marriage Certificate", value: "marriageCertificate" },
+      { label: "Previous Proceeding Details", value: "previousProceedingDetails" },
+      { label: "Case Details Statement", value: "caseDetailsStatement" },
+      { label: "Other ( enter reason )", value: "other", target: "awaiting-clarification-options-other" }
+  ],
+  hideQuestion = false,
+  inline = true,
+  type = 'checkbox'
+) }}
+</div>
+
+<div class="js-hidden" id="awaiting-clarification-options-other">
+  <div class="form-group">
+    More details regarding clarification
+    <textarea class="form-control"
+              id="refusalClarificationAdditionalInfo"
+              name="refusalClarificationAdditionalInfo"
+              rows="4">{% if fields.refusalClarificationAdditionalInfo.value %}
+      {{ fields.refusalClarificationAdditionalInfo.value }}{% endif %}</textarea>
+  </div>
 </div>
 {% endcall %}

--- a/mocks/steps/modify-session/sections/rawSession.html
+++ b/mocks/steps/modify-session/sections/rawSession.html
@@ -1,4 +1,4 @@
-<h2 class="govuk-heading-m">Modify raw session</h2>
+<!-- <h2 class="govuk-heading-m">Modify raw session</h2>
 
 <form id="rawSession" action="{{ postUrl | default(path if path else url) }}" method="post" class="form">
   <div id="jsoneditor" style="width: !100%; height: 500px;"></div>
@@ -31,3 +31,4 @@
   <input type="hidden" name="_csrf" value="{{ csurfCsrfToken }}">
   <input class="govuk-button" type="submit" value="Set case data">
 </form>
+ -->

--- a/package.json
+++ b/package.json
@@ -113,7 +113,8 @@
     "braces": "^2.3.1",
     "lodash": "^4.17.11",
     "assign-deep": ">=1.0.1",
-    "marked": ">=0.7.0"
+    "marked": ">=0.7.0",
+    "handlebars": ">=4.3.0"
   },
   "nyc": {
     "report-dir": "coverage",

--- a/resources/sessionToCosMapping.json
+++ b/resources/sessionToCosMapping.json
@@ -36,5 +36,7 @@
   "LivedApartSinceAdultery.livedApart.livedApartSinceAdultery": "livedApartSinceAdultery",
   "LivedApartSinceAdultery.livedApart.datesLivedTogether": "datesLivedTogether",
 
-  "Upload.files": "files"
+  "Upload.files": "files",
+
+  "CourtFeedback.response": "clarificationResponse"
 }

--- a/sonar-project.properties
+++ b/sonar-project.properties
@@ -6,6 +6,6 @@ sonar.sources=.
 sonar.tests=test
 sonar.language=js
 sonar.dynamicAnalysis=reuseReports
-sonar.exclusions=node_modules/**/*, test/**/*, mocks/**/*, assets/**/*, config/**/*, infrastructure/**/*, resources/**/*, views/**/*, coverage/**/*, app.js, server.js, steps/contact-divorce-team-error/ContactDivorceTeamError.html, steps/petition-progress-bar/PetitionProgressBar.step.js, steps/petition-progress-bar/petitionerStateTemplates.js
+sonar.exclusions=node_modules/**/*, test/**/*, mocks/**/*, assets/**/*, config/**/*, infrastructure/**/*, resources/**/*, views/**/*, coverage/**/*, app.js, server.js, steps/contact-divorce-team-error/ContactDivorceTeamError.html, steps/petition-progress-bar/PetitionProgressBar.step.js, steps/petition-progress-bar/petitionerStateTemplates.js, steps/petition-progress-bar/sections/awaitingClarification/PetitionProgressBar.awaitingClarification.template.html
 
 sonar.javascript.lcov.reportPaths=./coverage/lcov.info

--- a/steps/check-your-answers/CheckYourAnswers.content.json
+++ b/steps/check-your-answers/CheckYourAnswers.content.json
@@ -8,6 +8,7 @@
     "applyingForDecreeNisiClaimsCostsRespondent": "I’m asking the court to grant a decree dissolving my marriage and to order my {{ case.divorceWho }} to pay some or all of the divorce costs.",
     "applyingForDecreeNisiClaimsCostsCoRespondent": "I’m asking the court to grant a decree dissolving my marriage and to order the co-respondent to pay some or all of the divorce costs.",
     "applyingForDecreeNisiClaimsCostsRespondentCoRespondent": "I’m asking the court to grant a decree dissolving my marriage and to order my {{ case.divorceWho }} and co-respondent to pay some or all of the divorce costs.",
+    "needToProvide": "See the court’s feedback",
 
     "facts": "I believe that the facts stated in this application are true.",
     "whatTheseStatments": "What these statements are",
@@ -22,7 +23,8 @@
 
     "fields": {
       "statementOfTruth": {
-        "yes": "I confirm that:"
+        "yes": "I confirm that:",
+        "clarificationYes": "I can confirm that I believe that the facts stated in this application are true."
       }
     },
 

--- a/steps/check-your-answers/CheckYourAnswers.html
+++ b/steps/check-your-answers/CheckYourAnswers.html
@@ -1,6 +1,7 @@
 {% extends "check-your-answers.njk" %}
 
 {% from "look-and-feel/components/fields.njk" import formSection, selectionButtons %}
+{% from "components/clarification-feedback.njk" import clarificationFeedback %}
 
 {% set title %}
   {{ content.title }}
@@ -13,56 +14,94 @@
   summaryTableCaption: content.summaryTableCaption
 } %}
 
+{% block preResults %}
+  {% if isAwaitingClarification %}
+    <details class="govuk-details">
+      <summary class="govuk-details__summary" aria-controls="details-content-0" aria-expanded="false">
+        <span class="govuk-details__summary-text">{{ content.needToProvide }}</span>
+      </summary>
+      <div class="govuk-details__text" id="details-content-0" aria-hidden="true">
+        {{ clarificationFeedback(case, content.clarificationCourtFeedback) }}
+      </div>
+    </details>
+  {% endif %}
+{% endblock %}
+
+
+
 {% block statement_of_truth_content %}
   <h2 class="govuk-heading-m">{{ content.confirm | safe }}</h2>
   <p class="govuk-body">{{ content.imprisonedOrContempt }}</p>
 {% endblock %}
 
 {% block statement_of_truth_fields %}
+  {% if isAwaitingClarification %}
 
-  <div class="confirmation-container govuk-!-padding-bottom-1">
-    {% call formSection() %}
-      {{
-        selectionButtons(
-          fields.statementOfTruth,
-          content.fields.statementOfTruth.yes,
-          options = [
-            { label: content.fields.statementOfTruth.yes, value: "yes" }
-          ],
-          hint=false,
-          hideQuestion=true,
-          inline=false,
-          type='checkbox'
-        )
-      }}
-    {% endcall %}
-
-    <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-5">
-      {% if dnClaimCosts and dnClaimCosts != "endClaim" %}
-        {% if case.claimsCostsFrom|length and "respondent" in case.claimsCostsFrom and "correspondent" in case.claimsCostsFrom  %}
-          <li>{{ content.applyingForDecreeNisiClaimsCostsRespondentCoRespondent }}</li>
-        {% elseif case.claimsCostsFrom|length and "correspondent" in case.claimsCostsFrom  %}
-          <li>{{ content.applyingForDecreeNisiClaimsCostsCoRespondent }}</li>
-        {% else %}
-          <li>{{ content.applyingForDecreeNisiClaimsCostsRespondent }}</li>
-        {% endif %}
-      {% else %}
-        <li>{{ content.applyingForDecreeNisi }}</li>
-      {% endif %}
-      <li>{{ content.facts }}</li>
-    </uL>
-
-    <br>
-
-    <details class="govuk-details">
-      <summary class="govuk-details__summary" aria-controls="details-content-0" aria-expanded="false">
-        <span class="govuk-details__summary-text">{{ content.whatTheseStatments }}</span>
-      </summary>
-      <div class="govuk-details__text" id="details-content-0" aria-hidden="true">
-        <p class="govuk-body">{{ content.firstStatment }}</p>
+    <div class="confirmation-container govuk-!-padding-bottom-1">
+        {% call formSection() %}
+          {{
+            selectionButtons(
+              fields.statementOfTruth,
+              content.fields.statementOfTruth.yes,
+              options = [
+                { label: content.fields.statementOfTruth.clarificationYes, value: "yes" }
+              ],
+              hint=false,
+              hideQuestion=true,
+              inline=false,
+              type='checkbox'
+            )
+          }}
+        {% endcall %}
       </div>
-    </details>
-  </div>
+
+  {% else %}
+
+    <div class="confirmation-container govuk-!-padding-bottom-1">
+      {% call formSection() %}
+        {{
+          selectionButtons(
+            fields.statementOfTruth,
+            content.fields.statementOfTruth.yes,
+            options = [
+              { label: content.fields.statementOfTruth.yes, value: "yes" }
+            ],
+            hint=false,
+            hideQuestion=true,
+            inline=false,
+            type='checkbox'
+          )
+        }}
+      {% endcall %}
+
+      <ul class="govuk-list govuk-list--bullet govuk-!-margin-top-5">
+        {% if dnClaimCosts and dnClaimCosts != "endClaim" %}
+          {% if case.claimsCostsFrom|length and "respondent" in case.claimsCostsFrom and "correspondent" in case.claimsCostsFrom  %}
+            <li>{{ content.applyingForDecreeNisiClaimsCostsRespondentCoRespondent }}</li>
+          {% elseif case.claimsCostsFrom|length and "correspondent" in case.claimsCostsFrom  %}
+            <li>{{ content.applyingForDecreeNisiClaimsCostsCoRespondent }}</li>
+          {% else %}
+            <li>{{ content.applyingForDecreeNisiClaimsCostsRespondent }}</li>
+          {% endif %}
+        {% else %}
+          <li>{{ content.applyingForDecreeNisi }}</li>
+        {% endif %}
+        <li>{{ content.facts }}</li>
+      </uL>
+
+      <br>
+
+      <details class="govuk-details">
+        <summary class="govuk-details__summary" aria-controls="details-content-0" aria-expanded="false">
+          <span class="govuk-details__summary-text">{{ content.whatTheseStatments }}</span>
+        </summary>
+        <div class="govuk-details__text" id="details-content-0" aria-hidden="true">
+          <p class="govuk-body">{{ content.firstStatment }}</p>
+        </div>
+      </details>
+    </div>
+
+  {% endif %}
 
   <br>
 {%- endblock %}

--- a/steps/check-your-answers/CheckYourAnswers.step.js
+++ b/steps/check-your-answers/CheckYourAnswers.step.js
@@ -6,11 +6,7 @@ const caseOrchestrationService = require('services/caseOrchestrationService');
 const { form, text } = require('@hmcts/one-per-page/forms');
 const Joi = require('joi');
 const { parseBool } = require('@hmcts/one-per-page/util');
-
-const constants = {
-  NotDefined: 'notdefined',
-  awaitingClarification: 'awaitingclarification'
-};
+const { notDefined, awaitingClarification } = require('common/constants');
 
 class CheckYourAnswers extends CYA {
   static get path() {
@@ -22,11 +18,11 @@ class CheckYourAnswers extends CYA {
   }
 
   get caseState() {
-    return this.req.session.case.state ? this.req.session.case.state.toLowerCase() : constants.NotDefined;
+    return this.req.session.case.state ? this.req.session.case.state.toLowerCase() : notDefined;
   }
 
   get isAwaitingClarification() {
-    return this.caseState === constants.awaitingClarification && parseBool(config.features.awaitingClarification);
+    return this.caseState === awaitingClarification && parseBool(config.features.awaitingClarification);
   }
 
   get dnClaimCosts() {

--- a/steps/check-your-answers/CheckYourAnswers.step.js
+++ b/steps/check-your-answers/CheckYourAnswers.step.js
@@ -5,6 +5,12 @@ const idam = require('services/idam');
 const caseOrchestrationService = require('services/caseOrchestrationService');
 const { form, text } = require('@hmcts/one-per-page/forms');
 const Joi = require('joi');
+const { parseBool } = require('@hmcts/one-per-page/util');
+
+const constants = {
+  NotDefined: 'notdefined',
+  awaitingClarification: 'awaitingclarification'
+};
 
 class CheckYourAnswers extends CYA {
   static get path() {
@@ -13,6 +19,14 @@ class CheckYourAnswers extends CYA {
 
   get case() {
     return this.req.session.case.data;
+  }
+
+  get caseState() {
+    return this.req.session.case.state ? this.req.session.case.state.toLowerCase() : constants.NotDefined;
+  }
+
+  get isAwaitingClarification() {
+    return this.caseState === constants.awaitingClarification && parseBool(config.features.awaitingClarification);
   }
 
   get dnClaimCosts() {

--- a/steps/check-your-answers/CheckYourAnswers.step.js
+++ b/steps/check-your-answers/CheckYourAnswers.step.js
@@ -22,7 +22,11 @@ class CheckYourAnswers extends CYA {
   }
 
   get isAwaitingClarification() {
-    return this.caseState === awaitingClarification && parseBool(config.features.awaitingClarification);
+    const isDnOutcomeCase = parseBool(this.case.dnOutcomeCase);
+    const featureIsEnabled = parseBool(config.features.awaitingClarification);
+    const isCorrectState = this.caseState === awaitingClarification;
+
+    return isDnOutcomeCase && featureIsEnabled && isCorrectState;
   }
 
   get dnClaimCosts() {

--- a/steps/court-feedback/CourtFeedback.content.json
+++ b/steps/court-feedback/CourtFeedback.content.json
@@ -1,0 +1,14 @@
+{
+  "en": {
+    "title": "Respond to the court's feedback?",
+    "needToProvide" : "See the court’s feedback",
+    "errors": {
+      "required": "You need to enter a response before continuing"
+    },
+    "fields": {
+      "response": {
+        "title": "Your response"
+      }
+    }
+  }
+}

--- a/steps/court-feedback/CourtFeedback.html
+++ b/steps/court-feedback/CourtFeedback.html
@@ -19,7 +19,8 @@
 
   {{ textarea(
     fields.response,
-    content.fields.response.title
+    content.fields.response.title,
+    bold=true
   ) }}
 
 {% endblock %}

--- a/steps/court-feedback/CourtFeedback.html
+++ b/steps/court-feedback/CourtFeedback.html
@@ -1,0 +1,25 @@
+{% extends "question.njk" %}
+
+{% from "look-and-feel/components/fields.njk" import textarea %}
+{% from "components/clarification-feedback.njk" import clarificationFeedback %}
+
+{% set title %}
+  {{ content.title | safe }}
+{% endset %}
+
+{% block fields %}
+  <details class="govuk-details">
+    <summary class="govuk-details__summary" aria-controls="details-content-0" aria-expanded="false">
+      <span class="govuk-details__summary-text">{{ content.needToProvide }}</span>
+    </summary>
+    <div class="govuk-details__text" id="details-content-0" aria-hidden="true">
+      {{ clarificationFeedback(case, content.clarificationCourtFeedback) }}
+    </div>
+  </details>
+
+  {{ textarea(
+    fields.response,
+    content.fields.response.title
+  ) }}
+
+{% endblock %}

--- a/steps/court-feedback/CourtFeedback.step.js
+++ b/steps/court-feedback/CourtFeedback.step.js
@@ -1,0 +1,45 @@
+/* eslint-disable max-len */
+const { Question } = require('@hmcts/one-per-page/steps');
+const { redirectTo } = require('@hmcts/one-per-page/flow');
+const config = require('config');
+const idam = require('services/idam');
+const Joi = require('joi');
+const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
+
+const { form, text } = require('@hmcts/one-per-page/forms');
+
+class CourtFeedback extends Question {
+  static get path() {
+    return config.paths.courtFeedback;
+  }
+
+  get case() {
+    return this.req.session.case.data;
+  }
+
+  get form() {
+    const validate = Joi.string()
+      .required();
+
+    const response = text.joi(this.content.errors.required, validate);
+
+    return form({ response });
+  }
+
+  next() {
+    return redirectTo(this.journey.steps.ShareCourtDocuments);
+  }
+
+  get middleware() {
+    return [...super.middleware, idam.protect()];
+  }
+
+  answers() {
+    return answer(this, {
+      question: this.content.fields.response.title,
+      answer: this.fields.response.value
+    });
+  }
+}
+
+module.exports = CourtFeedback;

--- a/steps/done/Done.content.json
+++ b/steps/done/Done.content.json
@@ -57,7 +57,8 @@
       "costsOrder": "Cost Order",
       "decreeNisi": "Decree Nisi",
       "dnAnswers": "Decree Nisi answers",
-      "decreeNisiRefusalOrder": "Refusal Order"
+      "decreeNisiRefusalOrderClarification": "Refusal Order",
+      "decreeNisiRefusalOrderRejection": "Refusal Order"
     }
   }
 }

--- a/steps/done/Done.content.json
+++ b/steps/done/Done.content.json
@@ -41,7 +41,7 @@
       "costsOrder": "Cost Order",
       "decreeNisi": "Decree Nisi",
       "dnAnswers": "Decree Nisi answers",
-      "refusalOrder": "Refusal Order"
+      "decreeNisiRefusalOrder": "Refusal Order"
     }
   }
 }

--- a/steps/done/Done.content.json
+++ b/steps/done/Done.content.json
@@ -24,6 +24,24 @@
     "madeFinal": "Divorce is complete",
 
     "courtWillCheck": "The court will check your application and pass it to the judge. If the judge agrees there is no reason why you should not get a divorce, you'll be sent the time, date and court in which your decree nisi will be pronounced.",
-    "decreeNisiGranted": "After the decree nisi has been granted, you'll have to wait 6 weeks before you can finalise your divorce by getting a decree absolute."
+    "decreeNisiGranted": "After the decree nisi has been granted, you'll have to wait 6 weeks before you can finalise your divorce by getting a decree absolute.",
+
+
+    "clarificationResponseSubmitted": "Response submitted",
+    "clarificationNext": "What happens next",
+    "clarificationYourResponse": "Your response will be checked by the court. You may be contacted again if the court needs further information. If your application passes these checks, your divorce will move on to the next stage.",
+    "clarificationContactUs": "You can contact us if you don’t hear anything back after 4 weeks.",
+
+    "downloadDocuments" : "Download your documents",
+    "files": {
+      "dpetition": "Divorce application",
+      "respondentAnswers": "Respondent's answers",
+      "coRespondentAnswers": "Co-Respondent's answers",
+      "certificateOfEntitlement": "Certificate of Entitlement",
+      "costsOrder": "Cost Order",
+      "decreeNisi": "Decree Nisi",
+      "dnAnswers": "Decree Nisi answers",
+      "refusalOrder": "Refusal Order"
+    }
   }
 }

--- a/steps/done/Done.content.json
+++ b/steps/done/Done.content.json
@@ -26,11 +26,27 @@
     "courtWillCheck": "The court will check your application and pass it to the judge. If the judge agrees there is no reason why you should not get a divorce, you'll be sent the time, date and court in which your decree nisi will be pronounced.",
     "decreeNisiGranted": "After the decree nisi has been granted, you'll have to wait 6 weeks before you can finalise your divorce by getting a decree absolute.",
 
-
-    "clarificationResponseSubmitted": "Response submitted",
-    "clarificationNext": "What happens next",
-    "clarificationYourResponse": "Your response will be checked by the court. You may be contacted again if the court needs further information. If your application passes these checks, your divorce will move on to the next stage.",
-    "clarificationContactUs": "You can contact us if you don’t hear anything back after 4 weeks.",
+    "clarification": {
+        "responseSubmitted": "Response submitted",
+        "next": "What happens next",
+        "yourResponse": "Your response will be checked by the court. You may be contacted again if the court needs further information. If your application passes these checks, your divorce will move on to the next stage.",
+        "submitDocuments": "What to do if you've been asked to submit documents",
+        "submitDocumentsInfo": "If you’ve been asked to provide documents to support your application but you can send them by post or by email.",
+        "sendDocByPost": "Sending documents by post",
+        "sendDocByPostInfo": "To send documents by post, you must:",
+        "sendDocByPostRef": "Write your reference number on each document you send",
+        "sendDocByPostTo": "Post all your documents to:",
+        "sendDocByPostReturns": "Your certificate will be kept by the court and won't be returned to you.",
+        "sendDocByEmail": "Send your documents by email",
+        "sendDocByEmailInfo1": "You can also email your documents to the court. Include your reference number in the subject line of the email. Email your documents to: <a class=\"govuk-link\" href=\"mailto:divorcecase@justice.gov.uk\">divorcecase@justice.gov.uk</a>",
+        "sendDocByEmailInfo2": "Your application will be checked. If its correct, you'll be sent a notice telling you that your application has been issued (sent out). You'll also get a case number and a copy of the application stamped by the divorce centre.",
+        "sendDocByEmailInfo3": "Your wife will also receive a copy of the application and a form to return. If you have used adultery as your reason for divorce, and named the person that your wife committed adultery with, they will also get a copy and a form to return.",
+        "contactUs": "Contact the divorce centre if you don't hear anything back after 3 weeks.",
+        "helpImprove": "Help us improve this service",
+        "helpImproveDeveloped": "This is a new service which is still being developed. If you haven't already, please provide feedback on what you think of it and how it can be improved.",
+        "youNeedHelp": "If you need help",
+        "contactDivorceCentre": "You can contact the divorce centre if you need help with your application. Court staff can't give you legal advice however, and you should speak to a solicitor or legal adviser if you need help with that."
+    },
 
     "downloadDocuments" : "Download your documents",
     "files": {

--- a/steps/done/Done.html
+++ b/steps/done/Done.html
@@ -23,8 +23,6 @@
     </p>
   </div>
 
-  <p class="govuk-body">{{ content.emailConfirmation | safe }}</p>
-
   {{
     progressList({
       one: {
@@ -46,6 +44,8 @@
   }}
 
   <br>
+
+  <p class="govuk-body">{{ content.emailConfirmation | safe }}</p>
 
   {% if isAwaitingClarification %}
     <h2 class="govuk-heading-m">{{ content.clarificationNext }}</h2>

--- a/steps/done/Done.html
+++ b/steps/done/Done.html
@@ -50,7 +50,7 @@
   {% if isAwaitingClarification %}
     <h2 class="govuk-heading-m">{{ content.clarificationNext }}</h2>
     <p class="govuk-body">{{ content.clarificationYourResponse }}</p>
-    <p class="govuk-body">{{ content.clarificationContactUs }}Y</p>
+    <p class="govuk-body">{{ content.clarificationContactUs }}</p>
   {% else %}
     <p class="govuk-body">{{ content.courtWillCheck }}</p>
     <p class="govuk-body">{{ content.decreeNisiGranted }}</p>

--- a/steps/done/Done.html
+++ b/steps/done/Done.html
@@ -1,14 +1,19 @@
 {% extends "page.njk" %}
 
 {% from "look-and-feel/components/progress-list.njk" import progressList %}
+{% from "look-and-feel/components/document-list.njk" import documentList %}
 
 {% block back %}{% endblock %}
 {% block title %}{% endblock %}
 
 {% block main_content %}
   <div class="govuk-panel govuk-panel--confirmation">
-    <h1 class="govuk-panel__title govuk-!-margin-bottom-0">{{content.applicationComplete | safe}}</h1>
-    <p class="govuk-!-font-size-19 govuk-!-font-weight-bold govuk-!-margin-top-2 govuk-!-margin-bottom-0">{{ content.appliedForDecreeNisi }}</p>
+    {% if isAwaitingClarification %}
+      <h1 class="govuk-panel__title govuk-!-margin-bottom-0">{{content.clarificationResponseSubmitted | safe}}</h1>
+    {% else %}
+      <h1 class="govuk-panel__title govuk-!-margin-bottom-0">{{content.applicationComplete | safe}}</h1>
+      <p class="govuk-!-font-size-19 govuk-!-font-weight-bold govuk-!-margin-top-2 govuk-!-margin-bottom-0">{{ content.appliedForDecreeNisi }}</p>
+    {% endif %}
     <p class="govuk-panel__body govuk-!-margin-0 govuk-!-margin-top-2">
       <span class="govuk-!-font-size-19">{{ content.referenceNumber | safe }}</span>
       <br>
@@ -42,8 +47,16 @@
 
   <br>
 
-  <p class="govuk-body">{{ content.courtWillCheck }}</p>
-  <p class="govuk-body">{{ content.decreeNisiGranted }}</p>
+  {% if isAwaitingClarification %}
+    <h2 class="govuk-heading-m">{{ content.clarificationNext }}</h2>
+    <p class="govuk-body">{{ content.clarificationYourResponse }}</p>
+    <p class="govuk-body">{{ content.clarificationContactUs }}Y</p>
+  {% else %}
+    <p class="govuk-body">{{ content.courtWillCheck }}</p>
+    <p class="govuk-body">{{ content.decreeNisiGranted }}</p>
+  {% endif %}
+
+
 {% endblock %}
 
 {% block one_third %}

--- a/steps/done/Done.html
+++ b/steps/done/Done.html
@@ -9,7 +9,7 @@
 {% block main_content %}
   <div class="govuk-panel govuk-panel--confirmation">
     {% if isAwaitingClarification %}
-      <h1 class="govuk-panel__title govuk-!-margin-bottom-0">{{content.clarificationResponseSubmitted | safe}}</h1>
+      <h1 class="govuk-panel__title govuk-!-margin-bottom-0">{{content.clarification.responseSubmitted | safe}}</h1>
     {% else %}
       <h1 class="govuk-panel__title govuk-!-margin-bottom-0">{{content.applicationComplete | safe}}</h1>
       <p class="govuk-!-font-size-19 govuk-!-font-weight-bold govuk-!-margin-top-2 govuk-!-margin-bottom-0">{{ content.appliedForDecreeNisi }}</p>
@@ -48,9 +48,58 @@
   <p class="govuk-body">{{ content.emailConfirmation | safe }}</p>
 
   {% if isAwaitingClarification %}
-    <h2 class="govuk-heading-m">{{ content.clarificationNext }}</h2>
-    <p class="govuk-body">{{ content.clarificationYourResponse }}</p>
-    <p class="govuk-body">{{ content.clarificationContactUs }}</p>
+    <h2 class="govuk-heading-m">{{ content.clarification.next }}</h2>
+    <p class="govuk-body">{{ content.clarification.yourResponse }}</p>
+
+    {% if hasUploadedDocuments %}
+
+      <p class="govuk-body">{{ content.clarification.contactUs }}</p>
+
+    {% else %}
+
+      <h2 class="govuk-heading-m">{{ content.clarification.submitDocuments }}</h2>
+      <p class="govuk-body">{{ content.clarification.submitDocumentsInfo }}</p>
+
+      <h2 class="govuk-heading-m">{{ content.clarification.sendDocByPost }}</h2>
+      <p class="govuk-body">{{ content.clarification.sendDocByPostInfo }}</p>
+      <ul class="govuk-list govuk-list--number">
+        <li>{{ content.clarification.sendDocByPostRef }}</li>
+        <li>
+          <p class="govuk-body">{{ content.clarification.sendDocByPostTo }}</p>
+          <div class="govuk-inset-text">
+            {% if case.court[case.courts].serviceCentreName %}
+              {{ case.court[case.courts].serviceCentreName }}<br>
+            {% else %}
+              {{ content.yourCourt }}<br>
+            {% endif %}
+            {{ content.careOf if case.court[case.courts].serviceCentreName }}{{ case.court[case.courts].divorceCentre | safe}} <br>
+            {% if case.court[case.courts].poBox %}
+                {{ case.court[case.courts].poBox | safe }}<br>
+            {% endif %}
+            {{ case.court[case.courts].courtCity | safe }}<br>
+            {{ case.court[case.courts].postCode | safe }}<br>
+          </div>
+          <p class="govuk-body">{{ content.clarification.sendDocByPostReturns }}</p>
+        </li>
+      </ul>
+
+      <h2 class="govuk-heading-m">{{ content.clarification.sendDocByEmail }}</h2>
+      <p class="govuk-body">{{ content.clarification.sendDocByEmailInfo1 | safe }}</p>
+      <p class="govuk-body">{{ content.clarification.sendDocByEmailInfo2 }}</p>
+      <p class="govuk-body">{{ content.clarification.sendDocByEmailInfo3 }}</p>
+
+      <p class="govuk-body">{{ content.clarification.contactUs }}</p>
+
+    {% endif %}
+
+    <h2 class="govuk-heading-m">{{ content.clarification.helpImprove }}</h2>
+    <p class="govuk-body">{{ content.clarification.helpImproveDeveloped }}</p>
+
+    <h2 class="govuk-heading-m">{{ content.clarification.youNeedHelp }}</h2>
+    <p class="govuk-body">{{ content.clarification.contactDivorceCentre }}</p>
+    <p class="govuk-body"><a class="govuk-link" href="mailto:{{ content.divorceEmail }}">{{ content.divorceEmail }}</a></p>
+    <p class="govuk-body">{{ content.phoneNumber }}</p>
+    <p class="govuk-body">{{ content.openTimes }}</p>
   {% else %}
     <p class="govuk-body">{{ content.courtWillCheck }}</p>
     <p class="govuk-body">{{ content.decreeNisiGranted }}</p>

--- a/steps/done/Done.step.js
+++ b/steps/done/Done.step.js
@@ -15,7 +15,11 @@ class Done extends ExitPoint {
   }
 
   get isAwaitingClarification() {
-    return this.caseState === awaitingClarification && parseBool(config.features.awaitingClarification);
+    const isDnOutcomeCase = parseBool(this.case.dnOutcomeCase);
+    const featureIsEnabled = parseBool(config.features.awaitingClarification);
+    const isCorrectState = this.caseState === awaitingClarification;
+
+    return isDnOutcomeCase && featureIsEnabled && isCorrectState;
   }
 
   get case() {

--- a/steps/done/Done.step.js
+++ b/steps/done/Done.step.js
@@ -31,6 +31,14 @@ class Done extends ExitPoint {
     return createUris(this.case.d8, docConfig);
   }
 
+  get hasUploadedDocuments() {
+    if (this.req.session.Upload) {
+      const hasSubmittedFiles = this.req.session.Upload.files && this.req.session.Upload.files.length;
+      return hasSubmittedFiles;
+    }
+    return false;
+  }
+
   get middleware() {
     return [
       idam.protect(),

--- a/steps/done/Done.step.js
+++ b/steps/done/Done.step.js
@@ -3,11 +3,7 @@ const config = require('config');
 const idam = require('services/idam');
 const { createUris } = require('@hmcts/div-document-express-handler');
 const { parseBool } = require('@hmcts/one-per-page/util');
-
-const constants = {
-  NotDefined: 'notdefined',
-  awaitingClarification: 'awaitingclarification'
-};
+const { notDefined, awaitingClarification } = require('common/constants');
 
 class Done extends ExitPoint {
   static get path() {
@@ -15,11 +11,11 @@ class Done extends ExitPoint {
   }
 
   get caseState() {
-    return this.req.session.case.state ? this.req.session.case.state.toLowerCase() : constants.NotDefined;
+    return this.req.session.case.state ? this.req.session.case.state.toLowerCase() : notDefined;
   }
 
   get isAwaitingClarification() {
-    return this.caseState === constants.awaitingClarification && parseBool(config.features.awaitingClarification);
+    return this.caseState === awaitingClarification && parseBool(config.features.awaitingClarification);
   }
 
   get case() {

--- a/steps/done/Done.step.js
+++ b/steps/done/Done.step.js
@@ -1,14 +1,38 @@
 const { ExitPoint } = require('@hmcts/one-per-page');
 const config = require('config');
 const idam = require('services/idam');
+const { createUris } = require('@hmcts/div-document-express-handler');
+const { parseBool } = require('@hmcts/one-per-page/util');
+
+const constants = {
+  NotDefined: 'notdefined',
+  awaitingClarification: 'awaitingclarification'
+};
 
 class Done extends ExitPoint {
   static get path() {
     return config.paths.done;
   }
 
+  get caseState() {
+    return this.req.session.case.state ? this.req.session.case.state.toLowerCase() : constants.NotDefined;
+  }
+
+  get isAwaitingClarification() {
+    return this.caseState === constants.awaitingClarification && parseBool(config.features.awaitingClarification);
+  }
+
   get case() {
     return this.req.session.case.data;
+  }
+
+  get downloadableFiles() {
+    const docConfig = {
+      documentNamePath: config.document.documentNamePath,
+      documentWhiteList: config.document.filesWhiteList
+    };
+
+    return createUris(this.case.d8, docConfig);
   }
 
   get middleware() {

--- a/steps/petition-progress-bar/PetitionProgressBar.content.json
+++ b/steps/petition-progress-bar/PetitionProgressBar.content.json
@@ -43,7 +43,8 @@
       "certificateOfEntitlement": "Certificate of Entitlement",
       "costsOrder": "Cost Order",
       "decreeNisi": "Decree Nisi",
-      "dnAnswers": "Decree Nisi answers"
+      "dnAnswers": "Decree Nisi answers",
+      "refusalOrder": "Refusal Order"
     }
   }
 }

--- a/steps/petition-progress-bar/PetitionProgressBar.content.json
+++ b/steps/petition-progress-bar/PetitionProgressBar.content.json
@@ -44,7 +44,7 @@
       "costsOrder": "Cost Order",
       "decreeNisi": "Decree Nisi",
       "dnAnswers": "Decree Nisi answers",
-      "refusalOrder": "Refusal Order"
+      "decreeNisiRefusalOrder": "Refusal Order"
     }
   }
 }

--- a/steps/petition-progress-bar/PetitionProgressBar.content.json
+++ b/steps/petition-progress-bar/PetitionProgressBar.content.json
@@ -44,7 +44,8 @@
       "costsOrder": "Cost Order",
       "decreeNisi": "Decree Nisi",
       "dnAnswers": "Decree Nisi answers",
-      "decreeNisiRefusalOrder": "Refusal Order"
+      "decreeNisiRefusalOrderClarification": "Refusal Order",
+      "decreeNisiRefusalOrderRejection": "Refusal Order"
     }
   }
 }

--- a/steps/petition-progress-bar/PetitionProgressBar.step.js
+++ b/steps/petition-progress-bar/PetitionProgressBar.step.js
@@ -122,7 +122,11 @@ class PetitionProgressBar extends Interstitial {
 
   get refusalOrderFile() {
     return this.downloadableFiles.find(file => {
-      return file.type === 'decreeNisiRefusalOrder';
+      const isRefusalOrder = [
+        'decreeNisiRefusalOrderClarification',
+        'decreeNisiRefusalOrderRejection'
+      ].includes(file.type);
+      return isRefusalOrder;
     });
   }
 

--- a/steps/petition-progress-bar/PetitionProgressBar.step.js
+++ b/steps/petition-progress-bar/PetitionProgressBar.step.js
@@ -7,6 +7,7 @@ const { createUris } = require('@hmcts/div-document-express-handler');
 const checkCaseState = require('middleware/checkCaseState');
 const { get } = require('lodash');
 const { parseBool } = require('@hmcts/one-per-page/util');
+const { notDefined, awaitingClarification } = require('common/constants');
 
 const {
   caseStateMap,
@@ -21,10 +22,10 @@ const constants = {
   AOSCompleted: 'aoscompleted',
   AOSOverdue: 'aosoverdue',
   validAnswer: ['yes', 'no', 'nonoadmission'],
-  NotDefined: 'notdefined',
+  notDefined,
   DNAwaiting: 'awaitingdecreenisi',
   awaitingPronouncement: 'awaitingpronouncement',
-  awaitingClarification: 'awaitingclarification',
+  awaitingClarification,
   undefendedReason: '0',
   no: 'no',
   yes: 'yes'

--- a/steps/petition-progress-bar/PetitionProgressBar.step.js
+++ b/steps/petition-progress-bar/PetitionProgressBar.step.js
@@ -122,7 +122,7 @@ class PetitionProgressBar extends Interstitial {
 
   get refusalOrderFile() {
     return this.downloadableFiles.find(file => {
-      return file.type === 'refusalOrder';
+      return file.type === 'decreeNisiRefusalOrder';
     });
   }
 

--- a/steps/petition-progress-bar/PetitionProgressBar.step.js
+++ b/steps/petition-progress-bar/PetitionProgressBar.step.js
@@ -83,7 +83,11 @@ class PetitionProgressBar extends Interstitial {
   }
 
   get showCourtFeedback() {
-    return this.caseState === constants.awaitingClarification && parseBool(config.features.awaitingClarification);
+    const isDnOutcomeCase = parseBool(this.case.dnOutcomeCase);
+    const featureIsEnabled = parseBool(config.features.awaitingClarification);
+    const isCorrectState = this.caseState === constants.awaitingClarification;
+
+    return isDnOutcomeCase && featureIsEnabled && isCorrectState;
   }
 
   get showDnNoResponse() {
@@ -153,7 +157,7 @@ class PetitionProgressBar extends Interstitial {
     } else if (this.awaitingPronouncementWithHearingDate()) {
       template = awaitingPronouncementWithHearingDateTemplate;
     } else {
-      caseStateMap().forEach(dataMap => {
+      caseStateMap(this.case).forEach(dataMap => {
         if (dataMap.state.includes(this.caseState)) {
           template = dataMap.template;
         }

--- a/steps/petition-progress-bar/petitionerStateTemplates.js
+++ b/steps/petition-progress-bar/petitionerStateTemplates.js
@@ -1,7 +1,7 @@
 const config = require('config');
 const { parseBool } = require('@hmcts/one-per-page/util');
 
-const caseStateMap = () => {
+const caseStateMap = caseData => {
   const map = [
     {
       template: './sections/submitted/PetitionProgressBar.submitted.template.html',
@@ -37,7 +37,12 @@ const caseStateMap = () => {
     }
   ];
 
-  if (parseBool(config.features.awaitingClarification)) {
+  const isDnOutcomeCase = parseBool(caseData.dnOutcomeCase);
+  const awaitingClarificationEnabled = parseBool(
+    config.features.awaitingClarification
+  );
+
+  if (isDnOutcomeCase && awaitingClarificationEnabled) {
     // remove awaitingclarification state from awaitingSubmittedDN template
     const awaitingSubmittedDNTemplate = map[2];
     awaitingSubmittedDNTemplate.state = awaitingSubmittedDNTemplate.state

--- a/steps/petition-progress-bar/petitionerStateTemplates.js
+++ b/steps/petition-progress-bar/petitionerStateTemplates.js
@@ -1,38 +1,60 @@
-const caseStateMap = [
-  {
-    template: './sections/submitted/PetitionProgressBar.submitted.template.html',
-    state: ['submitted', 'awaitinghwfdecision', 'awaitingdocuments', 'pendingrejection', 'petitioncompleted']
-  },
-  {
-    template: './sections/issued/PetitionProgressBar.issued.template.html',
-    state: ['aosstarted', 'aosawaiting', 'issued']
-  },
-  {
-    template: './sections/awaitingSubmittedDN/PetitionProgressBar.awaitingSubmittedDN.template.html',
-    state: ['awaitinglegaladvisorreferral', 'awaitingconsideration', 'awaitingpronouncement', 'awaitingclarification']
-  },
-  {
-    template: './sections/defendedWithAnswer/PetitionProgressBar.defendedWithAnswer.template.html',
-    state: ['defendeddivorce']
-  },
-  {
-    template: './sections/defendedAwaitingAnswer/PetitionProgressBar.defendedAwaitingAnswer.template.html',
-    state: ['aossubmittedawaitinganswer']
-  },
-  {
-    template: './sections/respondentNotReplied/PetitionProgressBar.respondentNotReplied.template.html',
-    state: ['aosoverdue']
-  },
-  {
-    template: './sections/aosCompleted/PetitionProgressBar.aosCompleted.template.html',
-    state: ['aoscompleted']
-  },
-  {
-    template: './sections/decreeNisiGranted/PetitionProgressBar.decreeNisiGranted.template.html',
-    state: ['awaitingdecreeabsolute', 'dnpronounced']
+const config = require('config');
+const { parseBool } = require('@hmcts/one-per-page/util');
+
+const caseStateMap = () => {
+  const map = [
+    {
+      template: './sections/submitted/PetitionProgressBar.submitted.template.html',
+      state: ['submitted', 'awaitinghwfdecision', 'awaitingdocuments', 'pendingrejection', 'petitioncompleted']
+    },
+    {
+      template: './sections/issued/PetitionProgressBar.issued.template.html',
+      state: ['aosstarted', 'aosawaiting', 'issued']
+    },
+    {
+      template: './sections/awaitingSubmittedDN/PetitionProgressBar.awaitingSubmittedDN.template.html',
+      state: ['awaitinglegaladvisorreferral', 'awaitingconsideration', 'awaitingpronouncement', 'awaitingclarification']
+    },
+    {
+      template: './sections/defendedWithAnswer/PetitionProgressBar.defendedWithAnswer.template.html',
+      state: ['defendeddivorce']
+    },
+    {
+      template: './sections/defendedAwaitingAnswer/PetitionProgressBar.defendedAwaitingAnswer.template.html',
+      state: ['aossubmittedawaitinganswer']
+    },
+    {
+      template: './sections/respondentNotReplied/PetitionProgressBar.respondentNotReplied.template.html',
+      state: ['aosoverdue']
+    },
+    {
+      template: './sections/aosCompleted/PetitionProgressBar.aosCompleted.template.html',
+      state: ['aoscompleted']
+    },
+    {
+      template: './sections/decreeNisiGranted/PetitionProgressBar.decreeNisiGranted.template.html',
+      state: ['awaitingdecreeabsolute', 'dnpronounced']
+    }
+  ];
+
+  if (parseBool(config.features.awaitingClarification)) {
+    // remove awaitingclarification state from awaitingSubmittedDN template
+    const awaitingSubmittedDNTemplate = map[2];
+    awaitingSubmittedDNTemplate.state = awaitingSubmittedDNTemplate.state
+      .filter(state => {
+        return state !== 'awaitingclarification';
+      });
+
+    // add new template for awaitingclarification state
+    const newAwaitingClarificationTemplate = {
+      template: './sections/awaitingClarification/PetitionProgressBar.awaitingClarification.template.html',
+      state: ['awaitingclarification']
+    };
+    map.push(newAwaitingClarificationTemplate);
   }
 
-];
+  return map;
+};
 
 const caseIdDisplayStateMap = ['submitted', 'awaitinghwfdecision', 'awaitingdocuments', 'pendingrejection', 'petitioncompleted'];
 

--- a/steps/petition-progress-bar/sections/awaitingClarification/PetitionProgressBar.awaitingClarification.template.html
+++ b/steps/petition-progress-bar/sections/awaitingClarification/PetitionProgressBar.awaitingClarification.template.html
@@ -1,0 +1,39 @@
+{% from "look-and-feel/components/progress-list.njk" import progressList %}
+{% from "look-and-feel/components/document-list.njk" import documentList %}
+{% from "look-and-feel/components/warning-text.njk" import warningText %}
+{% from "components/clarification-feedback.njk" import clarificationFeedback %}
+
+{{
+  progressList({
+    one: {
+      label: content.youApply,
+      complete: true
+    },
+    two: {
+      label: content.husbandWifeMustRespond,
+      complete: true
+    },
+    three: {
+      label: content.getDecreeNisi,
+      current: true
+    },
+    four: {
+      label: content.madeFinal
+    }
+  })
+}}
+
+<h2 class="govuk-heading-m">{{ content.awaitingClarificationTitle }}</h2>
+<p class="govuk-body">{{ content.awaitingClarificationReviewOfCase | safe }}</p>
+
+<h2 class="govuk-heading-m">{{ content.awaitingClarificationCourtsFeedback }}</h2>
+{{ clarificationFeedback(case, content.clarificationCourtFeedback, true) }}
+<p class="govuk-body">{{ content.awaitingClarificationNotSatisfied | safe }}</p>
+
+<h2 class="govuk-heading-m">{{ content.awaitingClarificationDoNext }}</h2>
+<p class="govuk-body">{{ content.awaitingClarificationProvideResponse | safe }}</p>
+<p class="govuk-body">{{ content.awaitingClarificationSubmitDocuments | safe }}</p>
+
+<form action="{{ postUrl | default(path if path else url) }}" method="post" class="form">
+  <input role="button" draggable="false" class="govuk-button" type="submit" value="{{ content.continue }}">
+</form>

--- a/steps/petition-progress-bar/sections/awaitingClarification/PetitionProgressBar.content.awaitingClarification.json
+++ b/steps/petition-progress-bar/sections/awaitingClarification/PetitionProgressBar.content.awaitingClarification.json
@@ -1,6 +1,6 @@
 {
   "en" : {
-    "awaitingClarificationTitle": "You need to provide more information",
+    "awaitingClarificationTitle": "You need to provide more information or documents",
     "awaitingClarificationReviewOfCase": "Following a review of your case, the court is not yet satisfied that you are entitled to a decree of divorce.",
     "awaitingClarificationCourtsFeedback": "The court’s feedback",
     "awaitingClarificationNotSatisfied": "You can download and keep the court’s full <a class=\"govuk-link\" href=\"{{ refusalOrderFile.uri | safe }}\" target=\"_blank\" aria-label=\"This link will download the Refusal order PDF.\">Refusal Order ({{ refusalOrderFile.fileType | upper }})</a>.",

--- a/steps/petition-progress-bar/sections/awaitingClarification/PetitionProgressBar.content.awaitingClarification.json
+++ b/steps/petition-progress-bar/sections/awaitingClarification/PetitionProgressBar.content.awaitingClarification.json
@@ -1,0 +1,11 @@
+{
+  "en" : {
+    "awaitingClarificationTitle": "You need to provide more information",
+    "awaitingClarificationReviewOfCase": "Following a review of your case, the court is not yet satisfied that you are entitled to a decree of divorce.",
+    "awaitingClarificationCourtsFeedback": "The court’s feedback",
+    "awaitingClarificationNotSatisfied": "You can download and keep the court’s full <a class=\"govuk-link\" href=\"{{ refusalOrderFile.uri | safe }}\" target=\"_blank\" aria-label=\"This link will download the Refusal order PDF.\">Refusal Order ({{ refusalOrderFile.fileType | upper }})</a>.",
+    "awaitingClarificationDoNext": "What you need to do next",
+    "awaitingClarificationProvideResponse": "You need to provide a response to the court’s feedback before your application can proceed.",
+    "awaitingClarificationSubmitDocuments": "You will be able to submit additional documents online or by sending the original paper copies by post."
+  }
+}

--- a/steps/share-court-documents/ShareCourtDocuments.content.json
+++ b/steps/share-court-documents/ShareCourtDocuments.content.json
@@ -2,7 +2,12 @@
   "en": {
     "otherReasons" : {
       "title": "Do you need to upload any other documents?",
-      "extraDocuments": "You should only do this if you have acquired new documents since you first applied which are relevant to your application."  
+      "extraDocuments": "You should only do this if you have acquired new documents since you first applied which are relevant to your application."
+    },
+    "clarification": {
+      "title": "Do you want to submit additional documents?",
+      "extraDocs": "You must submit the documents requested by the court. You can also submit additional documents to support your response.",
+      "needToProvide": "See the court’s feedback"
     },
     "adultery": {
       "title": "Do you need to upload evidence of the adultery?",

--- a/steps/share-court-documents/ShareCourtDocuments.html
+++ b/steps/share-court-documents/ShareCourtDocuments.html
@@ -1,9 +1,12 @@
 {% extends "question.njk" %}
 
 {% from "look-and-feel/components/fields.njk" import formSection, selectionButtons %}
+{% from "components/clarification-feedback.njk" import clarificationFeedback %}
 
 {% set title %}
-  {% if respNotAdmittedAdultery %}
+  {% if isAwaitingClarification %}
+    {{ content.clarification.title | safe }}
+  {% elseif respNotAdmittedAdultery %}
     {{ content.adultery.title | safe }}
   {% else %}
     {{ content.otherReasons.title | safe }}
@@ -12,8 +15,18 @@
 
 {% block fields %}
 
+  {% if isAwaitingClarification %}
+    <details class="govuk-details">
+      <summary class="govuk-details__summary" aria-controls="details-content-0" aria-expanded="false">
+        <span class="govuk-details__summary-text">{{ content.clarification.needToProvide }}</span>
+      </summary>
+      <div class="govuk-details__text" id="details-content-0" aria-hidden="true">
+        {{ clarificationFeedback(case, content.clarificationCourtFeedback) }}
+      </div>
+    </details>
 
-  {% if respNotAdmittedAdultery %}
+    <p class="govuk-body">{{ content.clarification.extraDocs | safe }}</p>
+  {% elseif respNotAdmittedAdultery %}
     <p class="govuk-body">{{ content.adultery.adulteryDoc | safe }}</p>
     <p class="govuk-body">{{ content.adultery.extraDocs | safe }}</p>
   {% else %}

--- a/steps/share-court-documents/ShareCourtDocuments.step.js
+++ b/steps/share-court-documents/ShareCourtDocuments.step.js
@@ -6,15 +6,26 @@ const { answer } = require('@hmcts/one-per-page/checkYourAnswers');
 const config = require('config');
 const idam = require('services/idam');
 const Joi = require('joi');
+const { parseBool } = require('@hmcts/one-per-page/util');
 
 const constants = {
   adultery: 'adultery',
-  no: 'No'
+  no: 'No',
+  NotDefined: 'notdefined',
+  awaitingClarification: 'awaitingclarification'
 };
 
 class ShareCourtDocuments extends Question {
   static get path() {
     return config.paths.shareCoreDocuments;
+  }
+
+  get caseState() {
+    return this.req.session.case.state ? this.req.session.case.state.toLowerCase() : constants.NotDefined;
+  }
+
+  get isAwaitingClarification() {
+    return this.caseState === constants.awaitingClarification && parseBool(config.features.awaitingClarification);
   }
 
   get case() {

--- a/steps/share-court-documents/ShareCourtDocuments.step.js
+++ b/steps/share-court-documents/ShareCourtDocuments.step.js
@@ -7,12 +7,13 @@ const config = require('config');
 const idam = require('services/idam');
 const Joi = require('joi');
 const { parseBool } = require('@hmcts/one-per-page/util');
+const { notDefined, awaitingClarification } = require('common/constants');
 
 const constants = {
   adultery: 'adultery',
   no: 'No',
-  NotDefined: 'notdefined',
-  awaitingClarification: 'awaitingclarification'
+  notDefined,
+  awaitingClarification
 };
 
 class ShareCourtDocuments extends Question {

--- a/steps/share-court-documents/ShareCourtDocuments.step.js
+++ b/steps/share-court-documents/ShareCourtDocuments.step.js
@@ -50,11 +50,17 @@ class ShareCourtDocuments extends Question {
   }
 
   answers() {
+    let title = this.content.fields.upload.title;
+    if (this.isAwaitingClarification) {
+      title = this.content.clarification.title;
+    }
+
     const answers = [];
     answers.push(answer(this, {
-      question: this.content.fields.upload.title,
+      question: title,
       answer: this.content.fields.upload[this.fields.upload.value]
     }));
+
     return answers;
   }
 

--- a/steps/share-court-documents/ShareCourtDocuments.step.js
+++ b/steps/share-court-documents/ShareCourtDocuments.step.js
@@ -26,7 +26,11 @@ class ShareCourtDocuments extends Question {
   }
 
   get isAwaitingClarification() {
-    return this.caseState === constants.awaitingClarification && parseBool(config.features.awaitingClarification);
+    const isDnOutcomeCase = parseBool(this.case.dnOutcomeCase);
+    const featureIsEnabled = parseBool(config.features.awaitingClarification);
+    const isCorrectState = this.caseState === constants.awaitingClarification;
+
+    return isDnOutcomeCase && featureIsEnabled && isCorrectState;
   }
 
   get case() {

--- a/steps/upload/Upload.content.json
+++ b/steps/upload/Upload.content.json
@@ -1,13 +1,16 @@
 {
   "en": {
-    "title": "Upload documents",
+    "title": "Submit additional documents",
+    "imageIsNotEntireDocument": "If the image is not of the entire document and readable by court staff you may be asked to resubmit.",
+    "warning": "Warning",
+    "usePhone": "You can use your phone to do this now if it has a camera.",
     "uploadDigitalCopies": "You can upload digital copies here, or take a picture with your phone if it has a camera.",
+    "clarificationDigitalCopies": "Upload documents that you need to send to the court to respond to the refusal order.",
     "howToTake": "How to take the picture",
     "howToTakeInfo1": "Place your certificate on a flat service in a well lit room. Use a flash if you need to.",
     "howToTakeInfo2": "Take a good quality picture of the entire certificate. You should be able to see its edges.",
     "howToTakeInfo3": "Check that the image is in focus. You must be able to read all the writing on the certificate, including the handwriting. Zoom in if you need to check this.",
     "howToTakeInfo4": "Send the picture to this device (e.g. by email) and save it.",
-    "entireDocument": "The image must be of the entire document and has to be readable by court staff. You can upload most types of image.",
     "cantUpload": "I can't upload my documents",
     "sendByPost": "How to send in your documents by post",
     "continueWithApplication": "Continue with this application. When you're finished you'll be given a reference number and the address of the Courts and Tribunals Service Centre.",
@@ -37,7 +40,7 @@
     },
     "fields": {
       "files": {
-        "title": "Your uploaded documents"
+        "title": "Your submitted documents"
       }
     }
   }

--- a/steps/upload/Upload.html
+++ b/steps/upload/Upload.html
@@ -1,6 +1,7 @@
 {% extends "question.njk" %}
 
 {% from "look-and-feel/components/fields.njk" import formSection, selectionButtons %}
+{% from "look-and-feel/components/warning-text.njk" import warningText %}
 
 {% set title %}
   {{ content.title | safe }}
@@ -42,7 +43,21 @@
 
   {{ header(title, size='l') }}
 
-  <p class="govuk-body">{{ content.uploadDigitalCopies }}</p>
+  {% if isAwaitingClarification %}
+    <p class="govuk-body">{{ content.clarificationDigitalCopies }}</p>
+  {% else %}
+    <p class="govuk-body">{{ content.uploadDigitalCopies }}</p>
+  {% endif %}
+
+
+  {{ warningText({
+      text: content.imageIsNotEntireDocument,
+      iconFallbackText: content.warning
+  }) }}
+
+  <div class="govuk-inset-text">
+    <p class="govuk-body">{{ content.usePhone }}</p>
+  </div>
 
   <details class="govuk-details">
     <summary class="govuk-details__summary" aria-controls="details-content-1" aria-expanded="false">
@@ -57,8 +72,6 @@
       </ul>
     </div>
   </details>
-
-  <p class="govuk-body">{{ content.entireDocument }}</p>
 
   <div class="document-upload">
     <div class="fallback">

--- a/steps/upload/Upload.step.js
+++ b/steps/upload/Upload.step.js
@@ -14,6 +14,10 @@ class Upload extends Question {
     return config.paths.upload;
   }
 
+  get case() {
+    return this.req.session.case.data;
+  }
+
   get caseState() {
     return this.req.session.case.state ? this.req.session.case.state.toLowerCase() : notDefined;
   }

--- a/steps/upload/Upload.step.js
+++ b/steps/upload/Upload.step.js
@@ -6,10 +6,24 @@ const config = require('config');
 const idam = require('services/idam');
 const evidenceManagmentMiddleware = require('middleware/evidenceManagmentMiddleware');
 const errors = require('resources/errors');
+const { parseBool } = require('@hmcts/one-per-page/util');
+
+const constants = {
+  NotDefined: 'notdefined',
+  awaitingClarification: 'awaitingclarification'
+};
 
 class Upload extends Question {
   static get path() {
     return config.paths.upload;
+  }
+
+  get caseState() {
+    return this.req.session.case.state ? this.req.session.case.state.toLowerCase() : constants.NotDefined;
+  }
+
+  get isAwaitingClarification() {
+    return this.caseState === constants.awaitingClarification && parseBool(config.features.awaitingClarification);
   }
 
   get form() {
@@ -76,6 +90,11 @@ class Upload extends Question {
       answers.push(answer(this, {
         question: this.content.fields.files.title,
         answer: files
+      }));
+    } else {
+      answers.push(answer(this, {
+        question: this.content.fields.files.title,
+        answer: 'None'
       }));
     }
 

--- a/steps/upload/Upload.step.js
+++ b/steps/upload/Upload.step.js
@@ -7,11 +7,7 @@ const idam = require('services/idam');
 const evidenceManagmentMiddleware = require('middleware/evidenceManagmentMiddleware');
 const errors = require('resources/errors');
 const { parseBool } = require('@hmcts/one-per-page/util');
-
-const constants = {
-  NotDefined: 'notdefined',
-  awaitingClarification: 'awaitingclarification'
-};
+const { notDefined, awaitingClarification } = require('common/constants');
 
 class Upload extends Question {
   static get path() {
@@ -19,11 +15,11 @@ class Upload extends Question {
   }
 
   get caseState() {
-    return this.req.session.case.state ? this.req.session.case.state.toLowerCase() : constants.NotDefined;
+    return this.req.session.case.state ? this.req.session.case.state.toLowerCase() : notDefined;
   }
 
   get isAwaitingClarification() {
-    return this.caseState === constants.awaitingClarification && parseBool(config.features.awaitingClarification);
+    return this.caseState === awaitingClarification && parseBool(config.features.awaitingClarification);
   }
 
   get form() {

--- a/steps/upload/Upload.step.js
+++ b/steps/upload/Upload.step.js
@@ -19,7 +19,11 @@ class Upload extends Question {
   }
 
   get isAwaitingClarification() {
-    return this.caseState === awaitingClarification && parseBool(config.features.awaitingClarification);
+    const isDnOutcomeCase = parseBool(this.case.dnOutcomeCase);
+    const featureIsEnabled = parseBool(config.features.awaitingClarification);
+    const isCorrectState = this.caseState === awaitingClarification;
+
+    return isDnOutcomeCase && featureIsEnabled && isCorrectState;
   }
 
   get form() {

--- a/test/e2e/journeys/ccdStates/awaitingClarification.test.js
+++ b/test/e2e/journeys/ccdStates/awaitingClarification.test.js
@@ -97,6 +97,7 @@ describe('Case State: AwaitingClarification - feature AwaitingClarification is o
 
   after(() => {
     request.get.restore();
+    request.post.restore();
     feesAndPaymentsService.getFee.restore();
     sandbox.restore();
   });

--- a/test/e2e/journeys/ccdStates/awaitingClarification.test.js
+++ b/test/e2e/journeys/ccdStates/awaitingClarification.test.js
@@ -8,6 +8,10 @@ const Start = require('steps/start/Start.step');
 const IdamLogin = require('mocks/steps/idamLogin/IdamLogin.step');
 const petitionProgressBar = require('steps/petition-progress-bar/PetitionProgressBar.step');
 const Entry = require('steps/entry/Entry.step');
+const ShareCourtDocuments = require('steps/share-court-documents/ShareCourtDocuments.step');
+const CheckYourAnswers = require('steps/check-your-answers/CheckYourAnswers.step');
+const Done = require('steps/done/Done.step');
+const CourtFeedback = require('steps/court-feedback/CourtFeedback.step');
 
 const feesAndPaymentsService = require('services/feesAndPaymentsService');
 
@@ -15,8 +19,13 @@ const session = {
   respDefendsDivorce: null
 };
 
-describe('Case State :  AwaitingClarification', () => {
+describe('Case State: AwaitingClarification - feature AwaitingClarification is off', () => {
+  const sandbox = sinon.createSandbox();
   before(() => {
+    sandbox.stub(config, 'features').value({
+      awaitingClarification: false
+    });
+
     const getStub = sinon.stub(request, 'get');
     getStub
       .withArgs(sinon.match({
@@ -39,6 +48,7 @@ describe('Case State :  AwaitingClarification', () => {
   after(() => {
     request.get.restore();
     feesAndPaymentsService.getFee.restore();
+    sandbox.restore();
   });
 
   journey.test([
@@ -47,4 +57,67 @@ describe('Case State :  AwaitingClarification', () => {
     { step: Entry },
     { step: petitionProgressBar }
   ]);
+});
+
+describe('Case State: AwaitingClarification - feature AwaitingClarification is on', () => {
+  const sandbox = sinon.createSandbox();
+  let caseOrchestrationServiceSubmitStub = {};
+
+  before(() => {
+    sandbox.stub(config, 'features').value({
+      awaitingClarification: true
+    });
+
+    const getStub = sinon.stub(request, 'get');
+    const postStub = sinon.stub(request, 'post');
+
+    getStub
+      .withArgs(sinon.match({
+        uri: `${config.services.orchestrationService.getCaseUrl}`
+      }))
+      .resolves(merge({}, mockCaseResponse, {
+        state: 'AwaitingClarification',
+        data: session
+      }));
+
+    caseOrchestrationServiceSubmitStub = postStub
+      .withArgs(sinon.match({
+        uri: `${config.services.orchestrationService.submitCaseUrl}/${mockCaseResponse.caseId}`
+      }));
+    caseOrchestrationServiceSubmitStub.resolves();
+
+    sinon.stub(feesAndPaymentsService, 'getFee')
+      .resolves({
+        feeCode: 'FEE0002',
+        version: 4,
+        amount: 550.00,
+        description: 'Filing an application for a divorce, nullity or civil partnership dissolution – fees order 1.2.' // eslint-disable-line max-len
+      });
+  });
+
+  after(() => {
+    request.get.restore();
+    feesAndPaymentsService.getFee.restore();
+    sandbox.restore();
+  });
+
+  journey.test([
+    { step: Start },
+    { step: IdamLogin, body: { success: 'yes' } },
+    { step: Entry },
+    { step: petitionProgressBar },
+    { step: CourtFeedback, body: { response: 'some details' } },
+    { step: ShareCourtDocuments, body: { upload: 'no' } },
+    { step: CheckYourAnswers, body: { statementOfTruth: 'yes' } },
+    { step: Done }
+  ]);
+
+  it('submits correct body to case orchestration service', () => {
+    const body = {
+      clarificationResponse: 'some details',
+      statementOfTruth: 'yes',
+      uploadAnyOtherDocuments: 'no'
+    };
+    sinon.assert.calledWith(caseOrchestrationServiceSubmitStub, sinon.match.has('body', body));
+  });
 });

--- a/test/functional/pages/courtFeedback.js
+++ b/test/functional/pages/courtFeedback.js
@@ -1,0 +1,15 @@
+const CourtFeedback = require('steps/court-feedback/CourtFeedback.step');
+const ShareCourtDocuments = require('steps/share-court-documents/ShareCourtDocuments.step');
+const commonContent = require('common/content');
+
+function testCourtFeedback() {
+  const I = this;
+
+  I.amOnLoadedPage(CourtFeedback.path);
+  I.fillField('response', 'some details...');
+  I.navByClick(commonContent.en.continue);
+
+  I.seeCurrentUrlEquals(ShareCourtDocuments.path);
+}
+
+module.exports = { testCourtFeedback };

--- a/test/functional/paths/pages.js
+++ b/test/functional/paths/pages.js
@@ -49,6 +49,8 @@ Scenario('Pages', async I => {
 
   I.testDesertionAskedToResumeDN();
 
+  I.testCourtFeedback();
+
   I.testCheckYourAnswersPage();
 
   I.testDonePage();

--- a/test/unit/mock/steps/idamLogin.test.js
+++ b/test/unit/mock/steps/idamLogin.test.js
@@ -14,9 +14,9 @@ describe(modulePath, () => {
       'allAgentsBusy',
       'chatClosed',
       'chatAlreadyOpen',
-      'chatOpeningHours'
+      'chatOpeningHours',
+      'clarificationCourtFeedback'
     ];
-
     return content(IdamLogin, {}, { ignoreContent });
   });
 

--- a/test/unit/mock/steps/modifiySession.test.js
+++ b/test/unit/mock/steps/modifiySession.test.js
@@ -19,7 +19,8 @@ const ignoreContent = [
   'chatOpeningHours',
   'phoneTitle',
   'emailTitle',
-  'responseTime'
+  'responseTime',
+  'clarificationCourtFeedback'
 ];
 
 describe(modulePath, () => {

--- a/test/unit/steps/accessibilityStatement.test.js
+++ b/test/unit/steps/accessibilityStatement.test.js
@@ -14,7 +14,8 @@ describe(modulePath, () => {
       'allAgentsBusy',
       'chatClosed',
       'chatAlreadyOpen',
-      'chatOpeningHours'
+      'chatOpeningHours',
+      'clarificationCourtFeedback'
     ];
     return content(PrivacyPolicy, {}, { ignoreContent });
   });

--- a/test/unit/steps/adulteryFirstFoundOut.test.js
+++ b/test/unit/steps/adulteryFirstFoundOut.test.js
@@ -29,7 +29,8 @@ describe(modulePath, () => {
       'allAgentsBusy',
       'chatClosed',
       'chatAlreadyOpen',
-      'chatOpeningHours'
+      'chatOpeningHours',
+      'clarificationCourtFeedback'
     ];
     return content(AdulteryFirstFoundOut, session, { ignoreContent });
   });

--- a/test/unit/steps/amendApplication.test.js
+++ b/test/unit/steps/amendApplication.test.js
@@ -53,7 +53,6 @@ describe(modulePath, () => {
   });
 
   it('renders the content', () => {
-    const ignoreContent = ['continue'];
     const session = { case: { data: {} } };
     const specificContent = [
       'start',
@@ -61,7 +60,7 @@ describe(modulePath, () => {
       'ifYouWantYour',
       'notAbleToRead'
     ];
-    return content(AmendApplication, session, { specificContent, ignoreContent });
+    return content(AmendApplication, session, { specificContent });
   });
 
   it('Sends request to amend endpoint and redirects to PFE', done => {

--- a/test/unit/steps/applyForDecreeNisi.test.js
+++ b/test/unit/steps/applyForDecreeNisi.test.js
@@ -31,7 +31,8 @@ describe(modulePath, () => {
       'allAgentsBusy',
       'chatClosed',
       'chatAlreadyOpen',
-      'chatOpeningHours'
+      'chatOpeningHours',
+      'clarificationCourtFeedback'
     ];
     return content(ApplyForDecreeNisi, session, { ignoreContent });
   });

--- a/test/unit/steps/behaviourContinuedSinceApplication.test.js
+++ b/test/unit/steps/behaviourContinuedSinceApplication.test.js
@@ -32,7 +32,8 @@ describe(modulePath, () => {
       'allAgentsBusy',
       'chatClosed',
       'chatAlreadyOpen',
-      'chatOpeningHours'
+      'chatOpeningHours',
+      'clarificationCourtFeedback'
     ];
     return content(BehaviourContinuedSinceApplication, session, { ignoreContent });
   });

--- a/test/unit/steps/checkYouAnswers.test.js
+++ b/test/unit/steps/checkYouAnswers.test.js
@@ -91,7 +91,7 @@ describe(modulePath, () => {
 
       describe('show refusal reasons content', () => {
         it('feedback for jurisdictionDetails', () => {
-          session.case.data = { RefusalClarificationReason: ['jurisdictionDetails'] };
+          session.case.data = { refusalClarificationReason: ['jurisdictionDetails'] };
           const specificContent = [
             'clarificationCourtFeedback.jurisdictionDetails.title',
             'clarificationCourtFeedback.jurisdictionDetails.description'
@@ -100,7 +100,7 @@ describe(modulePath, () => {
         });
 
         it('feedback for marriageCertTranslation', () => {
-          session.case.data = { RefusalClarificationReason: ['marriageCertTranslation'] };
+          session.case.data = { refusalClarificationReason: ['marriageCertTranslation'] };
           const specificContent = [
             'clarificationCourtFeedback.marriageCertTranslation.title',
             'clarificationCourtFeedback.marriageCertTranslation.description',
@@ -111,7 +111,7 @@ describe(modulePath, () => {
         });
 
         it('feedback for marriageCertificate', () => {
-          session.case.data = { RefusalClarificationReason: ['marriageCertificate'] };
+          session.case.data = { refusalClarificationReason: ['marriageCertificate'] };
           const specificContent = [
             'clarificationCourtFeedback.marriageCertificate.title',
             'clarificationCourtFeedback.marriageCertificate.description'
@@ -120,7 +120,7 @@ describe(modulePath, () => {
         });
 
         it('feedback for previousProceedingDetails', () => {
-          session.case.data = { RefusalClarificationReason: ['previousProceedingDetails'] };
+          session.case.data = { refusalClarificationReason: ['previousProceedingDetails'] };
           const specificContent = [
             'clarificationCourtFeedback.previousProceedingDetails.title',
             'clarificationCourtFeedback.previousProceedingDetails.description'
@@ -129,7 +129,7 @@ describe(modulePath, () => {
         });
 
         it('feedback for caseDetailsStatement', () => {
-          session.case.data = { RefusalClarificationReason: ['caseDetailsStatement'] };
+          session.case.data = { refusalClarificationReason: ['caseDetailsStatement'] };
           const specificContent = [
             'clarificationCourtFeedback.caseDetailsStatement.title',
             'clarificationCourtFeedback.caseDetailsStatement.description'
@@ -139,8 +139,8 @@ describe(modulePath, () => {
 
         it('feedback for other', () => {
           session.case.data = {
-            RefusalClarificationReason: ['other'],
-            RefusalClarificationAdditionalInfo: 'some extra info'
+            refusalClarificationReason: ['other'],
+            refusalClarificationAdditionalInfo: 'some extra info'
           };
           const specificContent = [ 'clarificationCourtFeedback.other.title' ];
           const specificValues = [ 'some extra info' ];

--- a/test/unit/steps/checkYouAnswers.test.js
+++ b/test/unit/steps/checkYouAnswers.test.js
@@ -5,6 +5,7 @@ const Done = require('steps/done/Done.step');
 const idam = require('services/idam');
 const { middleware, question, sinon, content } = require('@hmcts/one-per-page-test-suite');
 const caseOrchestrationService = require('services/caseOrchestrationService');
+const config = require('config');
 
 describe(modulePath, () => {
   beforeEach(() => {
@@ -19,25 +20,163 @@ describe(modulePath, () => {
     return middleware.hasMiddleware(CheckYourAnswers, [ idam.protect() ]);
   });
 
-  it('renders the content', () => {
-    const ignoreContent = [
-      'applyingForDecreeNisi',
-      'applyingForDecreeNisiClaimsCostsRespondent',
-      'applyingForDecreeNisiClaimsCostsCoRespondent',
-      'applyingForDecreeNisiClaimsCostsRespondentCoRespondent',
-      'continue',
-      'webChatTitle',
-      'chatDown',
-      'chatWithAnAgent',
-      'noAgentsAvailable',
-      'allAgentsBusy',
-      'chatClosed',
-      'chatAlreadyOpen',
-      'chatOpeningHours'
-    ];
-    const session = { case: { data: {} } };
-    return content(CheckYourAnswers, session, { ignoreContent });
+  describe('content for decree nisi application', () => {
+    it('correct content', () => {
+      const ignoreContent = [
+        'applyingForDecreeNisi',
+        'applyingForDecreeNisiClaimsCostsRespondent',
+        'applyingForDecreeNisiClaimsCostsCoRespondent',
+        'applyingForDecreeNisiClaimsCostsRespondentCoRespondent',
+        'continue',
+        'clarificationCourtFeedback',
+        'needToProvide',
+        'webChatTitle',
+        'chatDown',
+        'chatWithAnAgent',
+        'noAgentsAvailable',
+        'allAgentsBusy',
+        'chatClosed',
+        'chatAlreadyOpen',
+        'chatOpeningHours'
+      ];
+      const session = { case: { data: {} } };
+      return content(CheckYourAnswers, session, { ignoreContent });
+    });
+
+    it('does not display and clarification content', () => {
+      const specificContentToNotExist = [
+        'clarificationCourtFeedback',
+        'needToProvide',
+        'fields.statementOfTruth.clarification'
+      ];
+      const session = { case: { data: {} } };
+      return content(CheckYourAnswers, session, { specificContentToNotExist });
+    });
   });
+
+  describe(
+    'clarification content feature:awaitingClarificiation is enabled, state is awaitingClarificiation', // eslint-disable-line
+    () => {
+      let sandbox = {};
+
+      before(() => {
+        sandbox = sinon.createSandbox();
+        sandbox.stub(config, 'features').value({
+          awaitingClarification: true
+        });
+      });
+
+      after(() => {
+        sandbox.restore();
+      });
+
+      let session = {};
+      beforeEach(() => {
+        session = {
+          case: {
+            state: 'AwaitingClarification',
+            data: {}
+          }
+        };
+      });
+
+      it('should show correct content', () => {
+        const specificContent = [
+          'needToProvide',
+          'fields.statementOfTruth.clarificationYes'
+        ];
+
+        return content(CheckYourAnswers, session, { specificContent });
+      });
+
+      describe('show refusal reasons content', () => {
+        it('feedback for jurisdictionDetails', () => {
+          session.case.data = { RefusalClarificationReason: ['jurisdictionDetails'] };
+          const specificContent = [
+            'clarificationCourtFeedback.jurisdictionDetails.title',
+            'clarificationCourtFeedback.jurisdictionDetails.description'
+          ];
+          return content(CheckYourAnswers, session, { specificContent });
+        });
+
+        it('feedback for marriageCertTranslation', () => {
+          session.case.data = { RefusalClarificationReason: ['marriageCertTranslation'] };
+          const specificContent = [
+            'clarificationCourtFeedback.marriageCertTranslation.title',
+            'clarificationCourtFeedback.marriageCertTranslation.description',
+            'clarificationCourtFeedback.marriageCertTranslation.method1',
+            'clarificationCourtFeedback.marriageCertTranslation.method2'
+          ];
+          return content(CheckYourAnswers, session, { specificContent });
+        });
+
+        it('feedback for marriageCertificate', () => {
+          session.case.data = { RefusalClarificationReason: ['marriageCertificate'] };
+          const specificContent = [
+            'clarificationCourtFeedback.marriageCertificate.title',
+            'clarificationCourtFeedback.marriageCertificate.description'
+          ];
+          return content(CheckYourAnswers, session, { specificContent });
+        });
+
+        it('feedback for previousProceedingDetails', () => {
+          session.case.data = { RefusalClarificationReason: ['previousProceedingDetails'] };
+          const specificContent = [
+            'clarificationCourtFeedback.previousProceedingDetails.title',
+            'clarificationCourtFeedback.previousProceedingDetails.description'
+          ];
+          return content(CheckYourAnswers, session, { specificContent });
+        });
+
+        it('feedback for caseDetailsStatement', () => {
+          session.case.data = { RefusalClarificationReason: ['caseDetailsStatement'] };
+          const specificContent = [
+            'clarificationCourtFeedback.caseDetailsStatement.title',
+            'clarificationCourtFeedback.caseDetailsStatement.description'
+          ];
+          return content(CheckYourAnswers, session, { specificContent });
+        });
+
+        it('feedback for other', () => {
+          session.case.data = {
+            RefusalClarificationReason: ['other'],
+            RefusalClarificationAdditionalInfo: 'some extra info'
+          };
+          const specificContent = [ 'clarificationCourtFeedback.other.title' ];
+          const specificValues = [ 'some extra info' ];
+          return content(CheckYourAnswers, session, { specificContent, specificValues });
+        });
+      });
+    }
+  );
+
+  describe(
+    'does not show content for Awaiting Clarification if awaitingClarification is disabled',
+    () => {
+      let sandbox = {};
+
+      before(() => {
+        sandbox = sinon.createSandbox();
+        sandbox.stub(config, 'features').value({
+          awaitingClarification: false
+        });
+      });
+
+      after(() => {
+        sandbox.restore();
+      });
+
+      it('does not display and clarification content', () => {
+        const specificContentToNotExist = [
+          'clarificationCourtFeedback',
+          'needToProvide',
+          'fields.statementOfTruth.clarification'
+        ];
+        const session = { case: { state: 'AwaitingClarification', data: {} } };
+        return content(CheckYourAnswers, session, { specificContentToNotExist });
+      });
+    }
+  );
 
   describe('errors', () => {
     beforeEach(() => {

--- a/test/unit/steps/checkYouAnswers.test.js
+++ b/test/unit/steps/checkYouAnswers.test.js
@@ -75,7 +75,7 @@ describe(modulePath, () => {
         session = {
           case: {
             state: 'AwaitingClarification',
-            data: {}
+            data: { dnOutcomeCase: true }
           }
         };
       });
@@ -91,7 +91,10 @@ describe(modulePath, () => {
 
       describe('show refusal reasons content', () => {
         it('feedback for jurisdictionDetails', () => {
-          session.case.data = { refusalClarificationReason: ['jurisdictionDetails'] };
+          session.case.data = {
+            refusalClarificationReason: ['jurisdictionDetails'],
+            dnOutcomeCase: true
+          };
           const specificContent = [
             'clarificationCourtFeedback.jurisdictionDetails.title',
             'clarificationCourtFeedback.jurisdictionDetails.description'
@@ -100,7 +103,10 @@ describe(modulePath, () => {
         });
 
         it('feedback for marriageCertTranslation', () => {
-          session.case.data = { refusalClarificationReason: ['marriageCertTranslation'] };
+          session.case.data = {
+            refusalClarificationReason: ['marriageCertTranslation'],
+            dnOutcomeCase: true
+          };
           const specificContent = [
             'clarificationCourtFeedback.marriageCertTranslation.title',
             'clarificationCourtFeedback.marriageCertTranslation.description',
@@ -111,7 +117,10 @@ describe(modulePath, () => {
         });
 
         it('feedback for marriageCertificate', () => {
-          session.case.data = { refusalClarificationReason: ['marriageCertificate'] };
+          session.case.data = {
+            refusalClarificationReason: ['marriageCertificate'],
+            dnOutcomeCase: true
+          };
           const specificContent = [
             'clarificationCourtFeedback.marriageCertificate.title',
             'clarificationCourtFeedback.marriageCertificate.description'
@@ -120,7 +129,10 @@ describe(modulePath, () => {
         });
 
         it('feedback for previousProceedingDetails', () => {
-          session.case.data = { refusalClarificationReason: ['previousProceedingDetails'] };
+          session.case.data = {
+            refusalClarificationReason: ['previousProceedingDetails'],
+            dnOutcomeCase: true
+          };
           const specificContent = [
             'clarificationCourtFeedback.previousProceedingDetails.title',
             'clarificationCourtFeedback.previousProceedingDetails.description'
@@ -129,7 +141,10 @@ describe(modulePath, () => {
         });
 
         it('feedback for caseDetailsStatement', () => {
-          session.case.data = { refusalClarificationReason: ['caseDetailsStatement'] };
+          session.case.data = {
+            refusalClarificationReason: ['caseDetailsStatement'],
+            dnOutcomeCase: true
+          };
           const specificContent = [
             'clarificationCourtFeedback.caseDetailsStatement.title',
             'clarificationCourtFeedback.caseDetailsStatement.description'
@@ -140,7 +155,8 @@ describe(modulePath, () => {
         it('feedback for other', () => {
           session.case.data = {
             refusalClarificationReason: ['other'],
-            refusalClarificationAdditionalInfo: 'some extra info'
+            refusalClarificationAdditionalInfo: 'some extra info',
+            dnOutcomeCase: true
           };
           const specificContent = [ 'clarificationCourtFeedback.other.title' ];
           const specificValues = [ 'some extra info' ];
@@ -172,7 +188,7 @@ describe(modulePath, () => {
           'needToProvide',
           'fields.statementOfTruth.clarification'
         ];
-        const session = { case: { state: 'AwaitingClarification', data: {} } };
+        const session = { case: { state: 'AwaitingClarification', data: { dnOutcomeCase: true } } };
         return content(CheckYourAnswers, session, { specificContentToNotExist });
       });
     }

--- a/test/unit/steps/claimCosts.test.js
+++ b/test/unit/steps/claimCosts.test.js
@@ -34,7 +34,8 @@ describe(modulePath, () => {
         'chatClosed',
         'chatAlreadyOpen',
         'chatOpeningHours',
-        'respNotPay'
+        'respNotPay',
+        'clarificationCourtFeedback'
       ];
       return content(ClaimCosts, sess, { ignoreContent });
     });
@@ -50,7 +51,8 @@ describe(modulePath, () => {
         'chatClosed',
         'chatAlreadyOpen',
         'chatOpeningHours',
-        'respPay'
+        'respPay',
+        'clarificationCourtFeedback'
       ];
       return content(ClaimCosts, sess, { ignoreContent });
     });

--- a/test/unit/steps/contactDivorceTeam.test.js
+++ b/test/unit/steps/contactDivorceTeam.test.js
@@ -14,9 +14,9 @@ describe(modulePath, () => {
       'chatClosed',
       'chatAlreadyOpen',
       'chatOpeningHours',
-      'continue'
+      'continue',
+      'clarificationCourtFeedback'
     ];
-
     return content(ContactDivorceTeam, {}, { ignoreContent });
   });
 });

--- a/test/unit/steps/contactDivorceTeamError.test.js
+++ b/test/unit/steps/contactDivorceTeamError.test.js
@@ -14,7 +14,8 @@ describe(modulePath, () => {
       'chatClosed',
       'chatAlreadyOpen',
       'chatOpeningHours',
-      'continue'
+      'continue',
+      'clarificationCourtFeedback'
     ];
     return content(ContactDivorceTeam, {}, { ignoreContent });
   });

--- a/test/unit/steps/courtFeedback.test.js
+++ b/test/unit/steps/courtFeedback.test.js
@@ -17,7 +17,17 @@ describe(modulePath, () => {
   describe('content', () => {
     it('renders the base content', () => {
       const session = { case: { data: {} } };
-      const ignoreContent = [ 'clarificationCourtFeedback' ];
+      const ignoreContent = [
+        'webChatTitle',
+        'chatDown',
+        'chatWithAnAgent',
+        'noAgentsAvailable',
+        'allAgentsBusy',
+        'chatClosed',
+        'chatAlreadyOpen',
+        'chatOpeningHours',
+        'clarificationCourtFeedback'
+      ];
       return content(CourtFeedback, session, { ignoreContent });
     });
 

--- a/test/unit/steps/courtFeedback.test.js
+++ b/test/unit/steps/courtFeedback.test.js
@@ -33,7 +33,7 @@ describe(modulePath, () => {
 
     describe('show refusal reasons content', () => {
       it('feedback for jurisdictionDetails', () => {
-        const session = { case: { data: { RefusalClarificationReason: ['jurisdictionDetails'] } } };
+        const session = { case: { data: { refusalClarificationReason: ['jurisdictionDetails'] } } };
         const specificContent = [
           'clarificationCourtFeedback.jurisdictionDetails.title',
           'clarificationCourtFeedback.jurisdictionDetails.description'
@@ -43,7 +43,7 @@ describe(modulePath, () => {
 
       it('feedback for marriageCertTranslation', () => {
         const session = { case: { data: {
-          RefusalClarificationReason: ['marriageCertTranslation']
+          refusalClarificationReason: ['marriageCertTranslation']
         } } };
         const specificContent = [
           'clarificationCourtFeedback.marriageCertTranslation.title',
@@ -55,7 +55,7 @@ describe(modulePath, () => {
       });
 
       it('feedback for marriageCertificate', () => {
-        const session = { case: { data: { RefusalClarificationReason: ['marriageCertificate'] } } };
+        const session = { case: { data: { refusalClarificationReason: ['marriageCertificate'] } } };
         const specificContent = [
           'clarificationCourtFeedback.marriageCertificate.title',
           'clarificationCourtFeedback.marriageCertificate.description'
@@ -65,7 +65,7 @@ describe(modulePath, () => {
 
       it('feedback for previousProceedingDetails', () => {
         const session = { case: { data: {
-          RefusalClarificationReason: ['previousProceedingDetails']
+          refusalClarificationReason: ['previousProceedingDetails']
         } } };
         const specificContent = [
           'clarificationCourtFeedback.previousProceedingDetails.title',
@@ -76,7 +76,7 @@ describe(modulePath, () => {
 
       it('feedback for caseDetailsStatement', () => {
         const session = { case: { data: {
-          RefusalClarificationReason: ['caseDetailsStatement']
+          refusalClarificationReason: ['caseDetailsStatement']
         } } };
         const specificContent = [
           'clarificationCourtFeedback.caseDetailsStatement.title',
@@ -87,8 +87,8 @@ describe(modulePath, () => {
 
       it('feedback for other', () => {
         const session = { case: { data: {
-          RefusalClarificationReason: ['other'],
-          RefusalClarificationAdditionalInfo: 'some extra info'
+          refusalClarificationReason: ['other'],
+          refusalClarificationAdditionalInfo: 'some extra info'
         } } };
         const specificContent = [ 'clarificationCourtFeedback.other.title' ];
         const specificValues = [ 'some extra info' ];

--- a/test/unit/steps/courtFeedback.test.js
+++ b/test/unit/steps/courtFeedback.test.js
@@ -1,0 +1,100 @@
+const modulePath = 'steps/court-feedback/CourtFeedback.step';
+
+const CourtFeedback = require(modulePath);
+const { content, sinon, middleware, question } = require('@hmcts/one-per-page-test-suite');
+const idam = require('services/idam');
+const ShareCourtDocuments = require('steps/share-court-documents/ShareCourtDocuments.step');
+
+describe(modulePath, () => {
+  beforeEach(() => {
+    sinon.stub(idam, 'protect').returns(middleware.nextMock);
+  });
+
+  afterEach(() => {
+    idam.protect.restore();
+  });
+
+  describe('content', () => {
+    it('renders the base content', () => {
+      const session = { case: { data: {} } };
+      const ignoreContent = [ 'clarificationCourtFeedback' ];
+      return content(CourtFeedback, session, { ignoreContent });
+    });
+
+    describe('show refusal reasons content', () => {
+      it('feedback for jurisdictionDetails', () => {
+        const session = { case: { data: { RefusalClarificationReason: ['jurisdictionDetails'] } } };
+        const specificContent = [
+          'clarificationCourtFeedback.jurisdictionDetails.title',
+          'clarificationCourtFeedback.jurisdictionDetails.description'
+        ];
+        return content(CourtFeedback, session, { specificContent });
+      });
+
+      it('feedback for marriageCertTranslation', () => {
+        const session = { case: { data: {
+          RefusalClarificationReason: ['marriageCertTranslation']
+        } } };
+        const specificContent = [
+          'clarificationCourtFeedback.marriageCertTranslation.title',
+          'clarificationCourtFeedback.marriageCertTranslation.description',
+          'clarificationCourtFeedback.marriageCertTranslation.method1',
+          'clarificationCourtFeedback.marriageCertTranslation.method2'
+        ];
+        return content(CourtFeedback, session, { specificContent });
+      });
+
+      it('feedback for marriageCertificate', () => {
+        const session = { case: { data: { RefusalClarificationReason: ['marriageCertificate'] } } };
+        const specificContent = [
+          'clarificationCourtFeedback.marriageCertificate.title',
+          'clarificationCourtFeedback.marriageCertificate.description'
+        ];
+        return content(CourtFeedback, session, { specificContent });
+      });
+
+      it('feedback for previousProceedingDetails', () => {
+        const session = { case: { data: {
+          RefusalClarificationReason: ['previousProceedingDetails']
+        } } };
+        const specificContent = [
+          'clarificationCourtFeedback.previousProceedingDetails.title',
+          'clarificationCourtFeedback.previousProceedingDetails.description'
+        ];
+        return content(CourtFeedback, session, { specificContent });
+      });
+
+      it('feedback for caseDetailsStatement', () => {
+        const session = { case: { data: {
+          RefusalClarificationReason: ['caseDetailsStatement']
+        } } };
+        const specificContent = [
+          'clarificationCourtFeedback.caseDetailsStatement.title',
+          'clarificationCourtFeedback.caseDetailsStatement.description'
+        ];
+        return content(CourtFeedback, session, { specificContent });
+      });
+
+      it('feedback for other', () => {
+        const session = { case: { data: {
+          RefusalClarificationReason: ['other'],
+          RefusalClarificationAdditionalInfo: 'some extra info'
+        } } };
+        const specificContent = [ 'clarificationCourtFeedback.other.title' ];
+        const specificValues = [ 'some extra info' ];
+        return content(CourtFeedback, session, { specificContent, specificValues });
+      });
+    });
+  });
+
+  it('shows error if response not answered', () => {
+    const session = { case: { data: { } } };
+    return question.testErrors(CourtFeedback, session);
+  });
+
+  it('redirects to the ShareCourtDocuments page', () => {
+    const fields = { response: 'some details' };
+    const session = { case: { data: { } } };
+    return question.redirectWithField(CourtFeedback, fields, ShareCourtDocuments, session);
+  });
+});

--- a/test/unit/steps/desertionAskedToResumeDN.test.js
+++ b/test/unit/steps/desertionAskedToResumeDN.test.js
@@ -33,9 +33,9 @@ describe(modulePath, () => {
       'allAgentsBusy',
       'chatClosed',
       'chatAlreadyOpen',
-      'chatOpeningHours'
+      'chatOpeningHours',
+      'clarificationCourtFeedback'
     ];
-
     return content(DesertionAskedToResumeDN, session, { ignoreContent });
   });
 

--- a/test/unit/steps/dnNoResponse.test.js
+++ b/test/unit/steps/dnNoResponse.test.js
@@ -26,14 +26,13 @@ describe('DnNoResponse step', () => {
 
 
   it('renders the content', () => {
-    const ignoreContent = ['continue'];
     const session = { case: { data: {} } };
     const specificContent = [
       'believeRespChoseNotToRespond.formD89',
       'applyD11',
       'doneWithAllWaysOfDelivering.applyD13bLink'
     ];
-    return content(DnNoResponse, session, { specificContent, ignoreContent });
+    return content(DnNoResponse, session, { specificContent });
   });
 
   it('getFeeFromFeesAndPayments middleware call', () => { // eslint-disable-line max-len

--- a/test/unit/steps/done.test.js
+++ b/test/unit/steps/done.test.js
@@ -111,7 +111,13 @@ describe(modulePath, () => {
               },
               {
                 id: '401ab79e-34cb-4570-9124-4cf9357m4st362',
-                fileName: 'decreeNisiRefusalOrder1559143445687032.pdf',
+                fileName: 'decreeNisiRefusalOrderRejection1559143445687032.pdf',
+                // eslint-disable-next-line max-len
+                fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560463'
+              },
+              {
+                id: '401ab79e-34cb-4570-9124-4cf9357m4st362',
+                fileName: 'decreeNisiRefusalOrderClarification1559143445687032.pdf',
                 // eslint-disable-next-line max-len
                 fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560463'
               },
@@ -182,7 +188,8 @@ describe(modulePath, () => {
         'files.costsOrder',
         'files.decreeNisi',
         'files.dnAnswers',
-        'files.decreeNisiRefusalOrder'
+        'files.decreeNisiRefusalOrderClarification',
+        'files.decreeNisiRefusalOrderRejection'
       ];
 
       return content(Done, session, { specificContent });

--- a/test/unit/steps/done.test.js
+++ b/test/unit/steps/done.test.js
@@ -78,6 +78,7 @@ describe(modulePath, () => {
         case: {
           state: 'AwaitingClarification',
           data: {
+            dnOutcomeCase: true,
             d8: [
               {
                 id: '401ab79e-34cb-4570-9f2f-4cf9357m4st3r',
@@ -219,7 +220,7 @@ describe(modulePath, () => {
           'downloadAndSaveYourDocuments',
           'files'
         ];
-        const session = { case: { state: 'AwaitingClarification', data: {} } };
+        const session = { case: { state: 'AwaitingClarification', data: { dnOutcomeCase: true } } };
         return content(Done, session, { specificContentToNotExist });
       });
     }

--- a/test/unit/steps/done.test.js
+++ b/test/unit/steps/done.test.js
@@ -118,7 +118,7 @@ describe(modulePath, () => {
               },
               {
                 id: '401ab79e-34cb-4570-9124-4cf9357m4st362',
-                fileName: 'refusalOrder1559143445687032.pdf',
+                fileName: 'decreeNisiRefusalOrder1559143445687032.pdf',
                 // eslint-disable-next-line max-len
                 fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560463'
               },
@@ -154,7 +154,7 @@ describe(modulePath, () => {
         'files.costsOrder',
         'files.decreeNisi',
         'files.dnAnswers',
-        'files.refusalOrder'
+        'files.decreeNisiRefusalOrder'
       ];
 
       return content(Done, session, { specificContent });

--- a/test/unit/steps/done.test.js
+++ b/test/unit/steps/done.test.js
@@ -26,11 +26,8 @@ describe(modulePath, () => {
   describe('content for decree nisi application', () => {
     it('correct content', () => {
       const ignoreContent = [
+        'clarification',
         'clarificationCourtFeedback',
-        'clarificationResponseSubmitted',
-        'clarificationNext',
-        'clarificationYourResponse',
-        'clarificationContactUs',
         'downloadDocuments',
         'downloadAndSaveYourDocuments',
         'files',
@@ -51,11 +48,7 @@ describe(modulePath, () => {
 
     it('does not display and clarification content', () => {
       const specificContentToNotExist = [
-        'clarificationCourtFeedback',
-        'clarificationResponseSubmitted',
-        'clarificationNext',
-        'clarificationYourResponse',
-        'clarificationContactUs',
+        'clarification',
         'downloadDocuments',
         'downloadAndSaveYourDocuments',
         'files'
@@ -140,12 +133,47 @@ describe(modulePath, () => {
       };
     });
 
-    it('should show correct content', () => {
+    it('should show correct content when files uploaded', () => {
+      const specificContentToNotExist = [
+        'clarification.submitDocuments',
+        'clarification.submitDocumentsInfo',
+        'clarification.sendDocByPost',
+        'clarification.sendDocByPostInfo',
+        'clarification.sendDocByPostRef',
+        'clarification.sendDocByPostTo',
+        'clarification.sendDocByPostReturns',
+        'clarification.sendDocByEmail',
+        'clarification.sendDocByEmailInfo1',
+        'clarification.sendDocByEmailInfo2',
+        'clarification.sendDocByEmailInfo3'
+      ];
+      session.Upload = {
+        files: [{ id: 'some-id' }]
+      };
+      return content(Done, session, { specificContentToNotExist });
+    });
+
+    it('should show correct content when no files uploaded', () => {
       const specificContent = [
-        'clarificationResponseSubmitted',
-        'clarificationNext',
-        'clarificationYourResponse',
-        'clarificationContactUs',
+        'clarification.responseSubmitted',
+        'clarification.next',
+        'clarification.yourResponse',
+        'clarification.submitDocuments',
+        'clarification.submitDocumentsInfo',
+        'clarification.sendDocByPost',
+        'clarification.sendDocByPostInfo',
+        'clarification.sendDocByPostRef',
+        'clarification.sendDocByPostTo',
+        'clarification.sendDocByPostReturns',
+        'clarification.sendDocByEmail',
+        'clarification.sendDocByEmailInfo1',
+        'clarification.sendDocByEmailInfo2',
+        'clarification.sendDocByEmailInfo3',
+        'clarification.contactUs',
+        'clarification.helpImprove',
+        'clarification.helpImproveDeveloped',
+        'clarification.youNeedHelp',
+        'clarification.contactDivorceCentre',
         'downloadDocuments',
         'files.dpetition',
         'files.respondentAnswers',
@@ -179,11 +207,7 @@ describe(modulePath, () => {
 
       it('does not display and clarification content', () => {
         const specificContentToNotExist = [
-          'clarificationCourtFeedback',
-          'clarificationResponseSubmitted',
-          'clarificationNext',
-          'clarificationYourResponse',
-          'clarificationContactUs',
+          'clarification',
           'downloadDocuments',
           'downloadAndSaveYourDocuments',
           'files'

--- a/test/unit/steps/done.test.js
+++ b/test/unit/steps/done.test.js
@@ -7,6 +7,7 @@ const { custom, expect, middleware, sinon, content } = require('@hmcts/one-per-p
 const httpStatus = require('http-status-codes');
 const { getExpectedCourtsList, testDivorceUnitDetailsRender,
   testCTSCDetailsRender } = require('test/unit/helpers/courtInformation');
+const config = require('config');
 
 describe(modulePath, () => {
   beforeEach(() => {
@@ -21,22 +22,177 @@ describe(modulePath, () => {
     return middleware.hasMiddleware(Done, [idam.protect(), idam.logout()]);
   });
 
-  it('renders the content', () => {
-    const session = { case: { data: {} } };
-    const ignoreContent = [
-      'webChatTitle',
-      'chatDown',
-      'chatWithAnAgent',
-      'noAgentsAvailable',
-      'allAgentsBusy',
-      'chatClosed',
-      'chatAlreadyOpen',
-      'chatOpeningHours',
-      'continue',
-      'careOf'
-    ];
-    return content(Done, session, { ignoreContent });
+
+  describe('content for decree nisi application', () => {
+    it('correct content', () => {
+      const ignoreContent = [
+        'clarificationCourtFeedback',
+        'clarificationResponseSubmitted',
+        'clarificationNext',
+        'clarificationYourResponse',
+        'clarificationContactUs',
+        'downloadDocuments',
+        'downloadAndSaveYourDocuments',
+        'files',
+        'webChatTitle',
+        'chatDown',
+        'chatWithAnAgent',
+        'noAgentsAvailable',
+        'allAgentsBusy',
+        'chatClosed',
+        'chatAlreadyOpen',
+        'chatOpeningHours',
+        'continue',
+        'careOf'
+      ];
+      const session = { case: { data: {} } };
+      return content(Done, session, { ignoreContent });
+    });
+
+    it('does not display and clarification content', () => {
+      const specificContentToNotExist = [
+        'clarificationCourtFeedback',
+        'clarificationResponseSubmitted',
+        'clarificationNext',
+        'clarificationYourResponse',
+        'clarificationContactUs',
+        'downloadDocuments',
+        'downloadAndSaveYourDocuments',
+        'files'
+      ];
+      const session = { case: { data: {} } };
+      return content(Done, session, { specificContentToNotExist });
+    });
   });
+
+  describe('content for clarification when awaitingClarification is enabled', () => {
+    let sandbox = {};
+
+    before(() => {
+      sandbox = sinon.createSandbox();
+      sandbox.stub(config, 'features').value({
+        awaitingClarification: true
+      });
+    });
+
+    after(() => {
+      sandbox.restore();
+    });
+
+    let session = {};
+    beforeEach(() => {
+      session = {
+        case: {
+          state: 'AwaitingClarification',
+          data: {
+            d8: [
+              {
+                id: '401ab79e-34cb-4570-9f2f-4cf9357m4st3r',
+                fileName: 'd8petition1554740111371638.pdf',
+                // eslint-disable-next-line max-len
+                fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560113f'
+              },
+              {
+                id: '401ab79e-34cb-4570-9124-4cf9357m4st3r',
+                fileName: 'certificateOfEntitlement1559143445687032.pdf',
+                // eslint-disable-next-line max-len
+                fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560113f'
+              },
+              {
+                id: '401ab79e-34cb-4570-9124-4cf9357m4st3r',
+                fileName: 'costsOrder1559143445687032.pdf',
+                // eslint-disable-next-line max-len
+                fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560113f'
+              },
+              {
+                id: '401ab79e-34cb-4570-9124-4cf9357m4st3r',
+                fileName: 'decreeNisi1559143445687032.pdf',
+                // eslint-disable-next-line max-len
+                fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560113f'
+              },
+              {
+                id: '401ab79e-34cb-4570-9124-4cf9357m4st3r',
+                fileName: 'dnAnswers1559143445687032.pdf',
+                // eslint-disable-next-line max-len
+                fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560113f'
+              },
+              {
+                id: '401ab79e-34cb-4570-9124-4cf9357m4st362',
+                fileName: 'refusalOrder1559143445687032.pdf',
+                // eslint-disable-next-line max-len
+                fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560463'
+              },
+              {
+                id: '401ab79e-34cb-4570-9124-4cf9357m4st362',
+                fileName: 'coRespondentAnswers1559143445687032.pdf',
+                // eslint-disable-next-line max-len
+                fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560333'
+              },
+              {
+                id: '401ab79e-34cb-4570-9124-4cf9357m4st362',
+                fileName: 'respondentAnswers1559143445687032.pdf',
+                // eslint-disable-next-line max-len
+                fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560222'
+              }
+            ]
+          }
+        }
+      };
+    });
+
+    it('should show correct content', () => {
+      const specificContent = [
+        'clarificationResponseSubmitted',
+        'clarificationNext',
+        'clarificationYourResponse',
+        'clarificationContactUs',
+        'downloadDocuments',
+        'files.dpetition',
+        'files.respondentAnswers',
+        'files.coRespondentAnswers',
+        'files.certificateOfEntitlement',
+        'files.costsOrder',
+        'files.decreeNisi',
+        'files.dnAnswers',
+        'files.refusalOrder'
+      ];
+
+      return content(Done, session, { specificContent });
+    });
+  });
+
+  describe(
+    'does not show content for Awaiting Clarification if awaitingClarification is disabled',
+    () => {
+      let sandbox = {};
+
+      before(() => {
+        sandbox = sinon.createSandbox();
+        sandbox.stub(config, 'features').value({
+          awaitingClarification: false
+        });
+      });
+
+      after(() => {
+        sandbox.restore();
+      });
+
+      it('does not display and clarification content', () => {
+        const specificContentToNotExist = [
+          'clarificationCourtFeedback',
+          'clarificationResponseSubmitted',
+          'clarificationNext',
+          'clarificationYourResponse',
+          'clarificationContactUs',
+          'downloadDocuments',
+          'downloadAndSaveYourDocuments',
+          'files'
+        ];
+        const session = { case: { state: 'AwaitingClarification', data: {} } };
+        return content(Done, session, { specificContentToNotExist });
+      });
+    }
+  );
 
   describe('values', () => {
     it('displays reference number', () => {

--- a/test/unit/steps/exit.test.js
+++ b/test/unit/steps/exit.test.js
@@ -47,7 +47,8 @@ describe(modulePath, () => {
         'serviceName',
         'signOut',
         'email',
-        'phone'
+        'phone',
+        'clarificationCourtFeedback'
       ];
 
       return content(

--- a/test/unit/steps/exitIntolerable.test.js
+++ b/test/unit/steps/exitIntolerable.test.js
@@ -14,8 +14,10 @@ describe(modulePath, () => {
       'chatClosed',
       'chatAlreadyOpen',
       'chatOpeningHours',
-      'continue'
+      'continue',
+      'clarificationCourtFeedback'
     ];
+
     const session = { case: { data: {} } };
     return content(ExitIntolerable, session, { ignoreContent });
   });

--- a/test/unit/steps/intolerable.test.js
+++ b/test/unit/steps/intolerable.test.js
@@ -34,7 +34,8 @@ describe(modulePath, () => {
       'allAgentsBusy',
       'chatClosed',
       'chatAlreadyOpen',
-      'chatOpeningHours'
+      'chatOpeningHours',
+      'clarificationCourtFeedback'
     ];
 
     return content(Intolerable, session, { ignoreContent });

--- a/test/unit/steps/livedApartSinceAdultery.test.js
+++ b/test/unit/steps/livedApartSinceAdultery.test.js
@@ -34,7 +34,8 @@ describe(modulePath, () => {
       'allAgentsBusy',
       'chatClosed',
       'chatAlreadyOpen',
-      'chatOpeningHours'
+      'chatOpeningHours',
+      'clarificationCourtFeedback'
     ];
 
     return content(LivedApartSinceAdultery, session, { ignoreContent });

--- a/test/unit/steps/livedApartSinceDesertion.test.js
+++ b/test/unit/steps/livedApartSinceDesertion.test.js
@@ -32,7 +32,8 @@ describe(modulePath, () => {
       'allAgentsBusy',
       'chatClosed',
       'chatAlreadyOpen',
-      'chatOpeningHours'
+      'chatOpeningHours',
+      'clarificationCourtFeedback'
     ];
 
     return content(LivedApartSinceDesertion, session, { ignoreContent });

--- a/test/unit/steps/livedApartSinceLastIncidentDate.test.js
+++ b/test/unit/steps/livedApartSinceLastIncidentDate.test.js
@@ -32,7 +32,8 @@ describe(modulePath, () => {
       'allAgentsBusy',
       'chatClosed',
       'chatAlreadyOpen',
-      'chatOpeningHours'
+      'chatOpeningHours',
+      'clarificationCourtFeedback'
     ];
 
     return content(LivedApartSinceLastIncidentDate, session, { ignoreContent });

--- a/test/unit/steps/livedApartSinceSeparation.test.js
+++ b/test/unit/steps/livedApartSinceSeparation.test.js
@@ -31,7 +31,8 @@ describe(modulePath, () => {
       'allAgentsBusy',
       'chatClosed',
       'chatAlreadyOpen',
-      'chatOpeningHours'
+      'chatOpeningHours',
+      'clarificationCourtFeedback'
     ];
 
     return content(LivedApartSinceSeparation, session, { ignoreContent });

--- a/test/unit/steps/miniPetition.test.js
+++ b/test/unit/steps/miniPetition.test.js
@@ -545,7 +545,8 @@ describe(modulePath, () => {
         'jurisdictionConnectionRespondent',
         'jurisdictionConnectionPetitionerSixMonths',
         'jurisdictionConnectionOther',
-        'onGoingCasesNo'
+        'onGoingCasesNo',
+        'clarificationCourtFeedback'
       ];
       return content(MiniPetition, session, { ignoreContent });
     });

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -670,7 +670,7 @@ describe(modulePath, () => {
                 createdOn: null,
                 lastModifiedBy: 0,
                 modifiedOn: null,
-                fileName: 'refusalOrder1559143445687032.pdf',
+                fileName: 'decreeNisiRefusalOrder1559143445687032.pdf',
                 // eslint-disable-next-line max-len
                 fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560463',
                 mimeType: null,
@@ -693,7 +693,7 @@ describe(modulePath, () => {
         'costsOrder',
         'decreeNisi',
         'dnAnswers',
-        'refusalOrder'
+        'decreeNisiRefusalOrder'
       ]);
     });
   });

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -822,7 +822,7 @@ describe(modulePath, () => {
 
       describe('show refusal reasons content', () => {
         it('feedback for jurisdictionDetails', () => {
-          session.case.data = { RefusalClarificationReason: ['jurisdictionDetails'] };
+          session.case.data = { refusalClarificationReason: ['jurisdictionDetails'] };
           const specificContent = [
             'clarificationCourtFeedback.jurisdictionDetails.title',
             'clarificationCourtFeedback.jurisdictionDetails.description'
@@ -831,7 +831,7 @@ describe(modulePath, () => {
         });
 
         it('feedback for marriageCertTranslation', () => {
-          session.case.data = { RefusalClarificationReason: ['marriageCertTranslation'] };
+          session.case.data = { refusalClarificationReason: ['marriageCertTranslation'] };
           const specificContent = [
             'clarificationCourtFeedback.marriageCertTranslation.title',
             'clarificationCourtFeedback.marriageCertTranslation.description',
@@ -842,7 +842,7 @@ describe(modulePath, () => {
         });
 
         it('feedback for marriageCertificate', () => {
-          session.case.data = { RefusalClarificationReason: ['marriageCertificate'] };
+          session.case.data = { refusalClarificationReason: ['marriageCertificate'] };
           const specificContent = [
             'clarificationCourtFeedback.marriageCertificate.title',
             'clarificationCourtFeedback.marriageCertificate.description'
@@ -851,7 +851,7 @@ describe(modulePath, () => {
         });
 
         it('feedback for previousProceedingDetails', () => {
-          session.case.data = { RefusalClarificationReason: ['previousProceedingDetails'] };
+          session.case.data = { refusalClarificationReason: ['previousProceedingDetails'] };
           const specificContent = [
             'clarificationCourtFeedback.previousProceedingDetails.title',
             'clarificationCourtFeedback.previousProceedingDetails.description'
@@ -860,7 +860,7 @@ describe(modulePath, () => {
         });
 
         it('feedback for caseDetailsStatement', () => {
-          session.case.data = { RefusalClarificationReason: ['caseDetailsStatement'] };
+          session.case.data = { refusalClarificationReason: ['caseDetailsStatement'] };
           const specificContent = [
             'clarificationCourtFeedback.caseDetailsStatement.title',
             'clarificationCourtFeedback.caseDetailsStatement.description'
@@ -870,8 +870,8 @@ describe(modulePath, () => {
 
         it('feedback for other', () => {
           session.case.data = {
-            RefusalClarificationReason: ['other'],
-            RefusalClarificationAdditionalInfo: 'some extra info'
+            refusalClarificationReason: ['other'],
+            refusalClarificationAdditionalInfo: 'some extra info'
           };
           const specificContent = [ 'clarificationCourtFeedback.other.title' ];
           const specificValues = [ 'some extra info' ];

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -1,6 +1,7 @@
 /* eslint-disable max-lines */
 const modulePath = 'steps/petition-progress-bar/PetitionProgressBar.step';
 
+const config = require('config');
 const PetitionProgressBar = require(modulePath);
 const PetProgressBarContent = require('steps/petition-progress-bar/PetitionProgressBar.content');
 const DnNoResponse = require('steps/dn-no-response/DnNoResponse.step');
@@ -40,7 +41,9 @@ const templates = {
   aosCompleted:
     './sections/aosCompleted/PetitionProgressBar.aosCompleted.template.html',
   decreeNisiGranted:
-    './sections/decreeNisiGranted/PetitionProgressBar.decreeNisiGranted.template.html'
+    './sections/decreeNisiGranted/PetitionProgressBar.decreeNisiGranted.template.html',
+  awaitingClarification:
+    './sections/awaitingClarification/PetitionProgressBar.awaitingClarification.template.html'
 };
 
 // get all content for all pages
@@ -660,6 +663,18 @@ describe(modulePath, () => {
                 fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560113f',
                 mimeType: null,
                 status: null
+              },
+              {
+                id: '401ab79e-34cb-4570-9124-4cf9357m4st362',
+                createdBy: 0,
+                createdOn: null,
+                lastModifiedBy: 0,
+                modifiedOn: null,
+                fileName: 'refusalOrder1559143445687032.pdf',
+                // eslint-disable-next-line max-len
+                fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560463',
+                mimeType: null,
+                status: null
               }
             ]
           }
@@ -677,7 +692,8 @@ describe(modulePath, () => {
         'certificateOfEntitlement',
         'costsOrder',
         'decreeNisi',
-        'dnAnswers'
+        'dnAnswers',
+        'refusalOrder'
       ]);
     });
   });
@@ -761,22 +777,130 @@ describe(modulePath, () => {
   });
 
   describe('CCD state: AwaitingClarification', () => {
-    const session = {
-      case: {
-        state: 'AwaitingClarification',
-        data: {}
-      }
-    };
+    let sandbox = {};
 
-    it('renders the correct content', () => {
-      const specificContent = Object.keys(pageContent.awaitingSubmittedDN);
-      const specificContentToNotExist = contentToNotExist('awaitingSubmittedDN');
-      return content(PetitionProgressBar, session, { specificContent, specificContentToNotExist });
+    before(() => {
+      sandbox = sinon.createSandbox();
     });
 
-    it('renders the correct template', () => {
-      const instance = stepAsInstance(PetitionProgressBar, session);
-      expect(instance.stateTemplate).to.eql(templates.awaitingSubmittedDN);
+    after(() => {
+      sandbox.restore();
+    });
+
+    let session = {};
+
+    beforeEach(() => {
+      session = {
+        case: {
+          state: 'AwaitingClarification',
+          data: {}
+        }
+      };
+    });
+
+    describe('feature: AwaitingClarification is true', () => {
+      before(() => {
+        sandbox.stub(config, 'features').value({
+          awaitingClarification: true
+        });
+      });
+
+      it('renders the correct content', () => {
+        const specificContent = Object.keys(pageContent.awaitingClarification);
+        const specificContentToNotExist = contentToNotExist('awaitingClarification');
+        return content(
+          PetitionProgressBar,
+          session,
+          { specificContent, specificContentToNotExist }
+        );
+      });
+
+      it('renders the correct template', () => {
+        const instance = stepAsInstance(PetitionProgressBar, session);
+        expect(instance.stateTemplate).to.eql(templates.awaitingClarification);
+      });
+
+      describe('show refusal reasons content', () => {
+        it('feedback for jurisdictionDetails', () => {
+          session.case.data = { RefusalClarificationReason: ['jurisdictionDetails'] };
+          const specificContent = [
+            'clarificationCourtFeedback.jurisdictionDetails.title',
+            'clarificationCourtFeedback.jurisdictionDetails.description'
+          ];
+          return content(PetitionProgressBar, session, { specificContent });
+        });
+
+        it('feedback for marriageCertTranslation', () => {
+          session.case.data = { RefusalClarificationReason: ['marriageCertTranslation'] };
+          const specificContent = [
+            'clarificationCourtFeedback.marriageCertTranslation.title',
+            'clarificationCourtFeedback.marriageCertTranslation.description',
+            'clarificationCourtFeedback.marriageCertTranslation.method1',
+            'clarificationCourtFeedback.marriageCertTranslation.method2'
+          ];
+          return content(PetitionProgressBar, session, { specificContent });
+        });
+
+        it('feedback for marriageCertificate', () => {
+          session.case.data = { RefusalClarificationReason: ['marriageCertificate'] };
+          const specificContent = [
+            'clarificationCourtFeedback.marriageCertificate.title',
+            'clarificationCourtFeedback.marriageCertificate.description'
+          ];
+          return content(PetitionProgressBar, session, { specificContent });
+        });
+
+        it('feedback for previousProceedingDetails', () => {
+          session.case.data = { RefusalClarificationReason: ['previousProceedingDetails'] };
+          const specificContent = [
+            'clarificationCourtFeedback.previousProceedingDetails.title',
+            'clarificationCourtFeedback.previousProceedingDetails.description'
+          ];
+          return content(PetitionProgressBar, session, { specificContent });
+        });
+
+        it('feedback for caseDetailsStatement', () => {
+          session.case.data = { RefusalClarificationReason: ['caseDetailsStatement'] };
+          const specificContent = [
+            'clarificationCourtFeedback.caseDetailsStatement.title',
+            'clarificationCourtFeedback.caseDetailsStatement.description'
+          ];
+          return content(PetitionProgressBar, session, { specificContent });
+        });
+
+        it('feedback for other', () => {
+          session.case.data = {
+            RefusalClarificationReason: ['other'],
+            RefusalClarificationAdditionalInfo: 'some extra info'
+          };
+          const specificContent = [ 'clarificationCourtFeedback.other.title' ];
+          const specificValues = [ 'some extra info' ];
+          return content(PetitionProgressBar, session, { specificContent, specificValues });
+        });
+      });
+    });
+
+    describe('feature: AwaitingClarification is false', () => {
+      before(() => {
+        sandbox.stub(config, 'features').value({
+          awaitingClarification: false
+        });
+      });
+
+      it('renders the correct content', () => {
+        const specificContent = Object.keys(pageContent.awaitingSubmittedDN);
+        const specificContentToNotExist = contentToNotExist('awaitingSubmittedDN');
+        return content(
+          PetitionProgressBar,
+          session,
+          { specificContent, specificContentToNotExist }
+        );
+      });
+
+      it('renders the correct template', () => {
+        const instance = stepAsInstance(PetitionProgressBar, session);
+        expect(instance.stateTemplate).to.eql(templates.awaitingSubmittedDN);
+      });
     });
   });
 

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -806,7 +806,7 @@ describe(modulePath, () => {
       session = {
         case: {
           state: 'AwaitingClarification',
-          data: {}
+          data: { dnOutcomeCase: true }
         }
       };
     });
@@ -835,7 +835,10 @@ describe(modulePath, () => {
 
       describe('show refusal reasons content', () => {
         it('feedback for jurisdictionDetails', () => {
-          session.case.data = { refusalClarificationReason: ['jurisdictionDetails'] };
+          session.case.data = {
+            refusalClarificationReason: ['jurisdictionDetails'],
+            dnOutcomeCase: true
+          };
           const specificContent = [
             'clarificationCourtFeedback.jurisdictionDetails.title',
             'clarificationCourtFeedback.jurisdictionDetails.description'
@@ -844,7 +847,10 @@ describe(modulePath, () => {
         });
 
         it('feedback for marriageCertTranslation', () => {
-          session.case.data = { refusalClarificationReason: ['marriageCertTranslation'] };
+          session.case.data = {
+            refusalClarificationReason: ['marriageCertTranslation'],
+            dnOutcomeCase: true
+          };
           const specificContent = [
             'clarificationCourtFeedback.marriageCertTranslation.title',
             'clarificationCourtFeedback.marriageCertTranslation.description',
@@ -855,7 +861,10 @@ describe(modulePath, () => {
         });
 
         it('feedback for marriageCertificate', () => {
-          session.case.data = { refusalClarificationReason: ['marriageCertificate'] };
+          session.case.data = {
+            refusalClarificationReason: ['marriageCertificate'],
+            dnOutcomeCase: true
+          };
           const specificContent = [
             'clarificationCourtFeedback.marriageCertificate.title',
             'clarificationCourtFeedback.marriageCertificate.description'
@@ -864,7 +873,10 @@ describe(modulePath, () => {
         });
 
         it('feedback for previousProceedingDetails', () => {
-          session.case.data = { refusalClarificationReason: ['previousProceedingDetails'] };
+          session.case.data = {
+            refusalClarificationReason: ['previousProceedingDetails'],
+            dnOutcomeCase: true
+          };
           const specificContent = [
             'clarificationCourtFeedback.previousProceedingDetails.title',
             'clarificationCourtFeedback.previousProceedingDetails.description'
@@ -873,7 +885,10 @@ describe(modulePath, () => {
         });
 
         it('feedback for caseDetailsStatement', () => {
-          session.case.data = { refusalClarificationReason: ['caseDetailsStatement'] };
+          session.case.data = {
+            refusalClarificationReason: ['caseDetailsStatement'],
+            dnOutcomeCase: true
+          };
           const specificContent = [
             'clarificationCourtFeedback.caseDetailsStatement.title',
             'clarificationCourtFeedback.caseDetailsStatement.description'
@@ -884,7 +899,8 @@ describe(modulePath, () => {
         it('feedback for other', () => {
           session.case.data = {
             refusalClarificationReason: ['other'],
-            refusalClarificationAdditionalInfo: 'some extra info'
+            refusalClarificationAdditionalInfo: 'some extra info',
+            dnOutcomeCase: true
           };
           const specificContent = [ 'clarificationCourtFeedback.other.title' ];
           const specificValues = [ 'some extra info' ];

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -670,7 +670,19 @@ describe(modulePath, () => {
                 createdOn: null,
                 lastModifiedBy: 0,
                 modifiedOn: null,
-                fileName: 'decreeNisiRefusalOrder1559143445687032.pdf',
+                fileName: 'decreeNisiRefusalOrderClarification1559143445687032.pdf',
+                // eslint-disable-next-line max-len
+                fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560463',
+                mimeType: null,
+                status: null
+              },
+              {
+                id: '401ab79e-34cb-4570-9124-4cf9357m4st362',
+                createdBy: 0,
+                createdOn: null,
+                lastModifiedBy: 0,
+                modifiedOn: null,
+                fileName: 'decreeNisiRefusalOrderRejection1559143445687032.pdf',
                 // eslint-disable-next-line max-len
                 fileUrl: 'http://dm-store-aat.service.core-compute-aat.internal/documents/30acaa2f-84d7-4e27-adb3-69551560463',
                 mimeType: null,
@@ -693,7 +705,8 @@ describe(modulePath, () => {
         'costsOrder',
         'decreeNisi',
         'dnAnswers',
-        'decreeNisiRefusalOrder'
+        'decreeNisiRefusalOrderClarification',
+        'decreeNisiRefusalOrderRejection'
       ]);
     });
   });

--- a/test/unit/steps/privacyPolicy.test.js
+++ b/test/unit/steps/privacyPolicy.test.js
@@ -20,7 +20,8 @@ describe(modulePath, () => {
         'chatAlreadyOpen',
         'chatOpeningHours',
         'continue',
-        'yourName'
+        'yourName',
+        'clarificationCourtFeedback'
       ];
 
       return content(PrivacyPolicy, {}, { ignoreContent });

--- a/test/unit/steps/respNotAdmitAdultery.test.js
+++ b/test/unit/steps/respNotAdmitAdultery.test.js
@@ -61,7 +61,8 @@ describe(modulePath, () => {
         'allAgentsBusy',
         'chatClosed',
         'chatAlreadyOpen',
-        'chatOpeningHours'
+        'chatOpeningHours',
+        'clarificationCourtFeedback'
       ];
 
       const session = {
@@ -73,6 +74,7 @@ describe(modulePath, () => {
           }
         }
       };
+
       return content(RespNotAdmitAdultery, session, { ignoreContent });
     });
 

--- a/test/unit/steps/reviewAosResponseFromCoRespondent.test.js
+++ b/test/unit/steps/reviewAosResponseFromCoRespondent.test.js
@@ -52,7 +52,8 @@ describe(modulePath, () => {
         'theCoRespondentResponseToAdulteryNo',
         'theCoRespondentDefendsTheDivorceNo',
         'theCoRespondentAgreeToPayCostsNo',
-        'corespondentDidNotRespond'
+        'corespondentDidNotRespond',
+        'clarificationCourtFeedback'
       ];
 
       return content(ReviewAosResponseFromCoRespondent, session, { ignoreContent });
@@ -85,7 +86,8 @@ describe(modulePath, () => {
         'theCoRespondentResponseToAdulteryYes',
         'theCoRespondentDefendsTheDivorceYes',
         'theCoRespondentAgreeToPayCostsYes',
-        'corespondentDidNotRespond'
+        'corespondentDidNotRespond',
+        'clarificationCourtFeedback'
       ];
       return content(ReviewAosResponseFromCoRespondent, session, { ignoreContent });
     });
@@ -116,7 +118,8 @@ describe(modulePath, () => {
         'theCoRespondentResponseToAdultery',
         'theCoRespondentDefendsTheDivorce',
         'theCoRespondentAgreeToPayCosts',
-        'youNeedToRead'
+        'youNeedToRead',
+        'clarificationCourtFeedback'
       ];
       return content(ReviewAosResponseFromCoRespondent, session, { ignoreContent });
     });
@@ -181,7 +184,8 @@ describe(modulePath, () => {
         'theCoRespondentResponseToAdulteryYes',
         'theCoRespondentDefendsTheDivorceYes',
         'theCoRespondentAgreeToPayCostsNo',
-        'corespondentDidNotRespond'
+        'corespondentDidNotRespond',
+        'clarificationCourtFeedback'
       ];
       const specificValuesToNotExist = ['It is the right thing to do...'];
       return content(ReviewAosResponseFromCoRespondent, session, {

--- a/test/unit/steps/shareCourtDocuments.test.js
+++ b/test/unit/steps/shareCourtDocuments.test.js
@@ -117,7 +117,7 @@ describe(modulePath, () => {
 
         describe('show refusal reasons content', () => {
           it('feedback for jurisdictionDetails', () => {
-            session.case.data = { RefusalClarificationReason: ['jurisdictionDetails'] };
+            session.case.data = { refusalClarificationReason: ['jurisdictionDetails'] };
             const specificContent = [
               'clarificationCourtFeedback.jurisdictionDetails.title',
               'clarificationCourtFeedback.jurisdictionDetails.description'
@@ -126,7 +126,7 @@ describe(modulePath, () => {
           });
 
           it('feedback for marriageCertTranslation', () => {
-            session.case.data = { RefusalClarificationReason: ['marriageCertTranslation'] };
+            session.case.data = { refusalClarificationReason: ['marriageCertTranslation'] };
             const specificContent = [
               'clarificationCourtFeedback.marriageCertTranslation.title',
               'clarificationCourtFeedback.marriageCertTranslation.description',
@@ -137,7 +137,7 @@ describe(modulePath, () => {
           });
 
           it('feedback for marriageCertificate', () => {
-            session.case.data = { RefusalClarificationReason: ['marriageCertificate'] };
+            session.case.data = { refusalClarificationReason: ['marriageCertificate'] };
             const specificContent = [
               'clarificationCourtFeedback.marriageCertificate.title',
               'clarificationCourtFeedback.marriageCertificate.description'
@@ -146,7 +146,7 @@ describe(modulePath, () => {
           });
 
           it('feedback for previousProceedingDetails', () => {
-            session.case.data = { RefusalClarificationReason: ['previousProceedingDetails'] };
+            session.case.data = { refusalClarificationReason: ['previousProceedingDetails'] };
             const specificContent = [
               'clarificationCourtFeedback.previousProceedingDetails.title',
               'clarificationCourtFeedback.previousProceedingDetails.description'
@@ -155,7 +155,7 @@ describe(modulePath, () => {
           });
 
           it('feedback for caseDetailsStatement', () => {
-            session.case.data = { RefusalClarificationReason: ['caseDetailsStatement'] };
+            session.case.data = { refusalClarificationReason: ['caseDetailsStatement'] };
             const specificContent = [
               'clarificationCourtFeedback.caseDetailsStatement.title',
               'clarificationCourtFeedback.caseDetailsStatement.description'
@@ -165,8 +165,8 @@ describe(modulePath, () => {
 
           it('feedback for other', () => {
             session.case.data = {
-              RefusalClarificationReason: ['other'],
-              RefusalClarificationAdditionalInfo: 'some extra info'
+              refusalClarificationReason: ['other'],
+              refusalClarificationAdditionalInfo: 'some extra info'
             };
             const specificContent = [ 'clarificationCourtFeedback.other.title' ];
             const specificValues = [ 'some extra info' ];

--- a/test/unit/steps/shareCourtDocuments.test.js
+++ b/test/unit/steps/shareCourtDocuments.test.js
@@ -101,7 +101,7 @@ describe(modulePath, () => {
           session = {
             case: {
               state: 'AwaitingClarification',
-              data: {}
+              data: { dnOutcomeCase: true }
             }
           };
         });
@@ -117,7 +117,10 @@ describe(modulePath, () => {
 
         describe('show refusal reasons content', () => {
           it('feedback for jurisdictionDetails', () => {
-            session.case.data = { refusalClarificationReason: ['jurisdictionDetails'] };
+            session.case.data = {
+              refusalClarificationReason: ['jurisdictionDetails'],
+              dnOutcomeCase: true
+            };
             const specificContent = [
               'clarificationCourtFeedback.jurisdictionDetails.title',
               'clarificationCourtFeedback.jurisdictionDetails.description'
@@ -126,7 +129,10 @@ describe(modulePath, () => {
           });
 
           it('feedback for marriageCertTranslation', () => {
-            session.case.data = { refusalClarificationReason: ['marriageCertTranslation'] };
+            session.case.data = {
+              refusalClarificationReason: ['marriageCertTranslation'],
+              dnOutcomeCase: true
+            };
             const specificContent = [
               'clarificationCourtFeedback.marriageCertTranslation.title',
               'clarificationCourtFeedback.marriageCertTranslation.description',
@@ -137,7 +143,10 @@ describe(modulePath, () => {
           });
 
           it('feedback for marriageCertificate', () => {
-            session.case.data = { refusalClarificationReason: ['marriageCertificate'] };
+            session.case.data = {
+              refusalClarificationReason: ['marriageCertificate'],
+              dnOutcomeCase: true
+            };
             const specificContent = [
               'clarificationCourtFeedback.marriageCertificate.title',
               'clarificationCourtFeedback.marriageCertificate.description'
@@ -146,7 +155,10 @@ describe(modulePath, () => {
           });
 
           it('feedback for previousProceedingDetails', () => {
-            session.case.data = { refusalClarificationReason: ['previousProceedingDetails'] };
+            session.case.data = {
+              refusalClarificationReason: ['previousProceedingDetails'],
+              dnOutcomeCase: true
+            };
             const specificContent = [
               'clarificationCourtFeedback.previousProceedingDetails.title',
               'clarificationCourtFeedback.previousProceedingDetails.description'
@@ -155,7 +167,10 @@ describe(modulePath, () => {
           });
 
           it('feedback for caseDetailsStatement', () => {
-            session.case.data = { refusalClarificationReason: ['caseDetailsStatement'] };
+            session.case.data = {
+              refusalClarificationReason: ['caseDetailsStatement'],
+              dnOutcomeCase: true
+            };
             const specificContent = [
               'clarificationCourtFeedback.caseDetailsStatement.title',
               'clarificationCourtFeedback.caseDetailsStatement.description'
@@ -165,6 +180,7 @@ describe(modulePath, () => {
 
           it('feedback for other', () => {
             session.case.data = {
+              dnOutcomeCase: true,
               refusalClarificationReason: ['other'],
               refusalClarificationAdditionalInfo: 'some extra info'
             };
@@ -199,7 +215,10 @@ describe(modulePath, () => {
             'clarification.extraDocs',
             'clarification.needToProvide'
           ];
-          const session = { case: { state: 'AwaitingClarification', data: {} } };
+          const session = { case: {
+            state: 'AwaitingClarification',
+            data: { dnOutcomeCase: true }
+          } };
           return content(ShareCourtDocuments, session, { specificContentToNotExist });
         });
       }

--- a/test/unit/steps/shareCourtDocuments.test.js
+++ b/test/unit/steps/shareCourtDocuments.test.js
@@ -5,6 +5,7 @@ const CheckYourAnswers = require('steps/check-your-answers/CheckYourAnswers.step
 const Upload = require('steps/upload/Upload.step');
 const idam = require('services/idam');
 const { middleware, question, sinon, content } = require('@hmcts/one-per-page-test-suite');
+const config = require('config');
 
 describe(modulePath, () => {
   beforeEach(() => {
@@ -40,7 +41,9 @@ describe(modulePath, () => {
         'allAgentsBusy',
         'chatClosed',
         'chatAlreadyOpen',
-        'chatOpeningHours'
+        'chatOpeningHours',
+        'clarificationCourtFeedback',
+        'clarification'
       ];
       return content(ShareCourtDocuments, session, { ignoreContent });
     });
@@ -76,6 +79,131 @@ describe(modulePath, () => {
       ];
       return content(ShareCourtDocuments, session, { specificContent });
     });
+
+    describe(
+      'clarification content feature:awaitingClarificiation is enabled, state is awaitingClarificiation', // eslint-disable-line
+      () => {
+        let sandbox = {};
+
+        before(() => {
+          sandbox = sinon.createSandbox();
+          sandbox.stub(config, 'features').value({
+            awaitingClarification: true
+          });
+        });
+
+        after(() => {
+          sandbox.restore();
+        });
+
+        let session = {};
+        beforeEach(() => {
+          session = {
+            case: {
+              state: 'AwaitingClarification',
+              data: {}
+            }
+          };
+        });
+
+        it('should show correct content', () => {
+          const specificContent = [
+            'clarification.title',
+            'clarification.extraDocs'
+          ];
+
+          return content(ShareCourtDocuments, session, { specificContent });
+        });
+
+        describe('show refusal reasons content', () => {
+          it('feedback for jurisdictionDetails', () => {
+            session.case.data = { RefusalClarificationReason: ['jurisdictionDetails'] };
+            const specificContent = [
+              'clarificationCourtFeedback.jurisdictionDetails.title',
+              'clarificationCourtFeedback.jurisdictionDetails.description'
+            ];
+            return content(ShareCourtDocuments, session, { specificContent });
+          });
+
+          it('feedback for marriageCertTranslation', () => {
+            session.case.data = { RefusalClarificationReason: ['marriageCertTranslation'] };
+            const specificContent = [
+              'clarificationCourtFeedback.marriageCertTranslation.title',
+              'clarificationCourtFeedback.marriageCertTranslation.description',
+              'clarificationCourtFeedback.marriageCertTranslation.method1',
+              'clarificationCourtFeedback.marriageCertTranslation.method2'
+            ];
+            return content(ShareCourtDocuments, session, { specificContent });
+          });
+
+          it('feedback for marriageCertificate', () => {
+            session.case.data = { RefusalClarificationReason: ['marriageCertificate'] };
+            const specificContent = [
+              'clarificationCourtFeedback.marriageCertificate.title',
+              'clarificationCourtFeedback.marriageCertificate.description'
+            ];
+            return content(ShareCourtDocuments, session, { specificContent });
+          });
+
+          it('feedback for previousProceedingDetails', () => {
+            session.case.data = { RefusalClarificationReason: ['previousProceedingDetails'] };
+            const specificContent = [
+              'clarificationCourtFeedback.previousProceedingDetails.title',
+              'clarificationCourtFeedback.previousProceedingDetails.description'
+            ];
+            return content(ShareCourtDocuments, session, { specificContent });
+          });
+
+          it('feedback for caseDetailsStatement', () => {
+            session.case.data = { RefusalClarificationReason: ['caseDetailsStatement'] };
+            const specificContent = [
+              'clarificationCourtFeedback.caseDetailsStatement.title',
+              'clarificationCourtFeedback.caseDetailsStatement.description'
+            ];
+            return content(ShareCourtDocuments, session, { specificContent });
+          });
+
+          it('feedback for other', () => {
+            session.case.data = {
+              RefusalClarificationReason: ['other'],
+              RefusalClarificationAdditionalInfo: 'some extra info'
+            };
+            const specificContent = [ 'clarificationCourtFeedback.other.title' ];
+            const specificValues = [ 'some extra info' ];
+            return content(ShareCourtDocuments, session, { specificContent, specificValues });
+          });
+        });
+      }
+    );
+
+    describe(
+      'does not show content for Awaiting Clarification if awaitingClarification is disabled',
+      () => {
+        let sandbox = {};
+
+        before(() => {
+          sandbox = sinon.createSandbox();
+          sandbox.stub(config, 'features').value({
+            awaitingClarification: false
+          });
+        });
+
+        after(() => {
+          sandbox.restore();
+        });
+
+        it('does not display and clarification content', () => {
+          const specificContentToNotExist = [
+            'clarificationCourtFeedback',
+            'clarification.title',
+            'clarification.extraDocs',
+            'clarification.needToProvide'
+          ];
+          const session = { case: { state: 'AwaitingClarification', data: {} } };
+          return content(ShareCourtDocuments, session, { specificContentToNotExist });
+        });
+      }
+    );
   });
 
   it('shows error if does not answer question', () => {

--- a/test/unit/steps/upload.test.js
+++ b/test/unit/steps/upload.test.js
@@ -105,7 +105,7 @@ describe(modulePath, () => {
           session = {
             case: {
               state: 'AwaitingClarification',
-              data: {}
+              data: { dnOutcomeCase: true }
             }
           };
         });
@@ -136,7 +136,10 @@ describe(modulePath, () => {
 
         it('does not display and clarification content', () => {
           const specificContentToNotExist = [ 'clarificationDigitalCopies' ];
-          const session = { case: { state: 'AwaitingClarification', data: {} } };
+          const session = { case: {
+            state: 'AwaitingClarification',
+            data: { dnOutcomeCase: true }
+          } };
           return content(Upload, session, { specificContentToNotExist });
         });
       }

--- a/views/check-your-answers.njk
+++ b/views/check-your-answers.njk
@@ -18,6 +18,8 @@
 
       {{ header(title, size=titleSize) }}
 
+      {% block preResults %}{% endblock %}
+
       <table class="govuk-table">
         <caption class="govuk-table__caption">
           <span class="govuk-visually-hidden">{{ pageContent.summaryTableCaption }}</span>

--- a/views/components/clarification-feedback.njk
+++ b/views/components/clarification-feedback.njk
@@ -1,5 +1,5 @@
 {#
-  calfication feedback
+  clarification feedback
     case                - (required) An object containing the case json
     content             - (required) An object of content for each feedback type
     displayAsError      - (optional) Boolean to display as error or not, defualt: false

--- a/views/components/clarification-feedback.njk
+++ b/views/components/clarification-feedback.njk
@@ -9,7 +9,7 @@
 
 {% macro clarificationFeedback(case, content, displayAsError=false) %}
   {{ '<div class="govuk-inset-text court-feedback">' | safe if displayAsError}}
-    {% for feedback in case.RefusalClarificationReason %}
+    {% for feedback in case.refusalClarificationReason %}
         <h3 class="govuk-heading-s">{{ content[feedback].title }}</h3>
         {% if feedback != "other" %}
           <p class="govuk-body">{{ content[feedback].description }}</p>
@@ -23,7 +23,7 @@
         {% endif %}
 
         {% if feedback == "other" %}
-          <p class="govuk-body">"{{ case.RefusalClarificationAdditionalInfo }}"</p>
+          <p class="govuk-body">"{{ case.refusalClarificationAdditionalInfo }}"</p>
         {% endif %}
 
     {% endfor %}

--- a/views/components/clarification-feedback.njk
+++ b/views/components/clarification-feedback.njk
@@ -1,0 +1,31 @@
+{#
+  calfication feedback
+    case                - (required) An object containing the case json
+    content             - (required) An object of content for each feedback type
+    displayAsError      - (optional) Boolean to display as error or not, defualt: false
+
+  renders a list of downloadable documents
+#}
+
+{% macro clarificationFeedback(case, content, displayAsError=false) %}
+  {{ '<div class="govuk-inset-text court-feedback">' | safe if displayAsError}}
+    {% for feedback in case.RefusalClarificationReason %}
+        <h3 class="govuk-heading-s">{{ content[feedback].title }}</h3>
+        {% if feedback != "other" %}
+          <p class="govuk-body">{{ content[feedback].description }}</p>
+        {% endif %}
+
+        {% if feedback == "marriageCertTranslation" %}
+          <ul class="govuk-list govuk-list--number">
+            <li>{{ content[feedback].method1 | safe }}</li>
+            <li>{{ content[feedback].method2 | safe }}</li>
+          </ul>
+        {% endif %}
+
+        {% if feedback == "other" %}
+          <p class="govuk-body">"{{ case.RefusalClarificationAdditionalInfo }}"</p>
+        {% endif %}
+
+    {% endfor %}
+  {{ '</div>' | safe if displayAsError }}
+{% endmacro %}

--- a/views/components/clarification-feedback.njk
+++ b/views/components/clarification-feedback.njk
@@ -16,7 +16,19 @@
         {% if key in case.refusalClarificationReason %}
           <h3 class="govuk-heading-s">{{ content[key].title }}</h3>
           {% if key != "other" %}
-            <p class="govuk-body">{{ content[key].description }}</p>
+            <p class="govuk-body">{{ content[key].description | safe }}</p>
+          {% endif %}
+
+          {% if key == "jurisdictionDetails" %}
+            <ul class="govuk-list govuk-list--bullet">
+              <li>{{ content[key].reason0 | safe }}</li>
+              <li>{{ content[key].reason1 | safe }}</li>
+              <li>{{ content[key].reason2 | safe }}</li>
+              <li>{{ content[key].reason3 | safe }}</li>
+              <li>{{ content[key].reason4 | safe }}</li>
+              <li>{{ content[key].reason5 | safe }}</li>
+              <li>{{ content[key].reason6 | safe }}</li>
+            </ul>
           {% endif %}
 
           {% if key == "marriageCertTranslation" %}

--- a/views/components/clarification-feedback.njk
+++ b/views/components/clarification-feedback.njk
@@ -7,25 +7,28 @@
   renders a list of downloadable documents
 #}
 
+{% set order = ["jurisdictionDetails", "marriageCertTranslation", "marriageCertificate", "previousProceedingDetails", "caseDetailsStatement", "other"] %}
+
 {% macro clarificationFeedback(case, content, displayAsError=false) %}
   {{ '<div class="govuk-inset-text court-feedback">' | safe if displayAsError}}
-    {% for feedback in case.refusalClarificationReason %}
-        <h3 class="govuk-heading-s">{{ content[feedback].title }}</h3>
-        {% if feedback != "other" %}
-          <p class="govuk-body">{{ content[feedback].description }}</p>
+    {% for key in order %}
+      {% if key in case.refusalClarificationReason %}
+        <h3 class="govuk-heading-s">{{ content[key].title }}</h3>
+        {% if key != "other" %}
+          <p class="govuk-body">{{ content[key].description }}</p>
         {% endif %}
 
-        {% if feedback == "marriageCertTranslation" %}
+        {% if key == "marriageCertTranslation" %}
           <ul class="govuk-list govuk-list--number">
-            <li>{{ content[feedback].method1 | safe }}</li>
-            <li>{{ content[feedback].method2 | safe }}</li>
+            <li>{{ content[key].method1 | safe }}</li>
+            <li>{{ content[key].method2 | safe }}</li>
           </ul>
         {% endif %}
 
-        {% if feedback == "other" %}
+        {% if key == "other" %}
           <p class="govuk-body">"{{ case.refusalClarificationAdditionalInfo }}"</p>
         {% endif %}
-
+      {% endif %}
     {% endfor %}
   {{ '</div>' | safe if displayAsError }}
 {% endmacro %}

--- a/views/components/clarification-feedback.njk
+++ b/views/components/clarification-feedback.njk
@@ -12,21 +12,23 @@
 {% macro clarificationFeedback(case, content, displayAsError=false) %}
   {{ '<div class="govuk-inset-text court-feedback">' | safe if displayAsError}}
     {% for key in order %}
-      {% if key in case.refusalClarificationReason %}
-        <h3 class="govuk-heading-s">{{ content[key].title }}</h3>
-        {% if key != "other" %}
-          <p class="govuk-body">{{ content[key].description }}</p>
-        {% endif %}
+      {% if case.refusalClarificationReason|length %}
+        {% if key in case.refusalClarificationReason %}
+          <h3 class="govuk-heading-s">{{ content[key].title }}</h3>
+          {% if key != "other" %}
+            <p class="govuk-body">{{ content[key].description }}</p>
+          {% endif %}
 
-        {% if key == "marriageCertTranslation" %}
-          <ul class="govuk-list govuk-list--number">
-            <li>{{ content[key].method1 | safe }}</li>
-            <li>{{ content[key].method2 | safe }}</li>
-          </ul>
-        {% endif %}
+          {% if key == "marriageCertTranslation" %}
+            <ul class="govuk-list govuk-list--number">
+              <li>{{ content[key].method1 | safe }}</li>
+              <li>{{ content[key].method2 | safe }}</li>
+            </ul>
+          {% endif %}
 
-        {% if key == "other" %}
-          <p class="govuk-body">"{{ case.refusalClarificationAdditionalInfo }}"</p>
+          {% if key == "other" %}
+            <p class="govuk-body">"{{ case.refusalClarificationAdditionalInfo }}"</p>
+          {% endif %}
         {% endif %}
       {% endif %}
     {% endfor %}

--- a/views/includes/sideMenu.html
+++ b/views/includes/sideMenu.html
@@ -1,6 +1,6 @@
 <aside class="govuk-related-items" role="complementary">
 
-    <h3 class="govuk-heading-s">{{ content.help }}</h3>
+    <h3 class="govuk-heading-m">{{ content.help }}</h3>
 
     <ul class="govuk-list govuk-body govuk-!-font-size-16 help">
         <li>
@@ -28,12 +28,12 @@
     </ul>
 
     {% if (downloadableFiles.length > 0) %}
-        <h3 class="govuk-heading-s">{{ content.downloadDocuments }}</h3>
+        <h3 class="govuk-heading-m">{{ content.downloadDocuments }}</h3>
 
         {{ documentList(downloadableFiles, content.files) }}
     {% endif %}
 
-    <h3 class="govuk-heading-s" id="subsection-title">{{ content.guidance }}</h3>
+    <h3 class="govuk-heading-m" id="subsection-title">{{ content.guidance }}</h3>
 
     <nav role="navigation" aria-labelledby="subsection-title">
       <ul class="govuk-list govuk-body govuk-!-font-size-16">

--- a/yarn.lock
+++ b/yarn.lock
@@ -4501,10 +4501,10 @@ growly@^1.2.0, growly@^1.3.0:
   resolved "https://registry.yarnpkg.com/growly/-/growly-1.3.0.tgz#f10748cbe76af964b7c96c93c6bcc28af120c081"
   integrity sha1-8QdIy+dq+WS3yWyTxrzCivEgwIE=
 
-handlebars@^4.0.1, handlebars@^4.0.3, handlebars@^4.1.2:
-  version "4.1.2"
-  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.1.2.tgz#b6b37c1ced0306b221e094fc7aca3ec23b131b67"
-  integrity sha512-nvfrjqvt9xQ8Z/w0ijewdD/vvWDTOweBUm96NTr66Wfvo1mJenBLwcYmPs3TIBP5ruzYGD7Hx/DaM9RmhroGPw==
+handlebars@>=4.3.0, handlebars@^4.0.1, handlebars@^4.0.3, handlebars@^4.1.2:
+  version "4.3.1"
+  resolved "https://registry.yarnpkg.com/handlebars/-/handlebars-4.3.1.tgz#6febc1890851f62a8932d495cc88d29390fa850d"
+  integrity sha512-c0HoNHzDiHpBt4Kqe99N8tdLPKAnGCQ73gYMPWtAYM4PwGnf7xl8PBUHJqh9ijlzt2uQKaSRxbXRt+rZ7M2/kA==
   dependencies:
     neo-async "^2.6.0"
     optimist "^0.6.1"


### PR DESCRIPTION
# Description

[DIV-5731 - Landing Page: Petitioner more information needed](https://tools.hmcts.net/jira/browse/DIV-5731)
 - Add new progress bar page section for Awaiting Clarification
 - Created common component to show courts feedback
 - Added feature toggle `awaitingClarification`

[DIV-5732 - Update 'respond to court's feedback' page after user testing](https://tools.hmcts.net/jira/browse/DIV-5732)
 - Add new page court feedback to capture petitioner response
 - Include common component to show courts feedback

[DIV-5733 - Do you want to submit additional docs? page](https://tools.hmcts.net/jira/browse/DIV-5733)
 - Updated content for question
 - Include common component to show courts feedback

[DIV-5736 - Clarification upload documents page](https://tools.hmcts.net/jira/browse/DIV-5736)
 - Updated content
 - Updated upload icon 

[DIV-5232 - More information - check your answers page](https://tools.hmcts.net/jira/browse/DIV-5232)
 - Added specific section for `statementOfTruth`
 - Include common component to show courts feedback

[DIV-5233 - Response Submitted (after clarification) done page](https://tools.hmcts.net/jira/browse/DIV-5233)
 - Add files to done page
 - Add specific content for awaiting clarification journey
 - Updated style for sidebar to be inline with prototype

**NOTE:** This could have been split into separate PR's, however for the following reasons i decided to keep as one PR:
- Work had already been completed on previous PR's so to pick up i just took the latest PR which based the previous PR's
- If i did split it out in order for the build to pass on individual PR's i would have to update unit tests which get updated in proceeding PR's ( waist of time )
- In order to test the proceeding PR's they would each be based of the previous PR and therefor be a pain to merge