### PR TITLE
DIV-5756 - Enable webchat on live environment

### DIFF
--- a/charts/div-dn/values.preview.template.yaml
+++ b/charts/div-dn/values.preview.template.yaml
@@ -9,7 +9,6 @@ nodejs:
         REDISCLOUD_URL: "redis://${SERVICE_NAME}-redis-master:6379"
         BASE_URL: "https://${SERVICE_NAME}.service.core-compute-preview.internal"
         PUBLIC_HOSTNAME: "https://${SERVICE_NAME}.service.core-compute-preview.internal"
-        FEATURE_WEBCHAT: "true"
     # Don't modify below here
     image: ${IMAGE_NAME}
     ingressHost: ${SERVICE_FQDN}

--- a/config/default.yml
+++ b/config/default.yml
@@ -139,7 +139,7 @@ tests:
 
 features:
   idam: false
-  webchat: false
+  webchat: true
   awaitingClarification: false
 
 journey:

--- a/infrastructure/variables.tf
+++ b/infrastructure/variables.tf
@@ -212,7 +212,7 @@ variable "appinsights_instrumentation_key" {
 }
 
 variable "feature_webchat" {
-  default = false
+  default = true
 }
 
 variable "webchat_chat_id" {


### PR DESCRIPTION
# Description

[DIV-5756 - Enable webchat on live environment](https://tools.hmcts.net/jira/browse/DIV-5756)
 - Remove chart specific config
 - Set webchat default to true
 - Set webchat default on true for PROD and AAT environments