### PR TITLE
Fix for issue with missing Solicitor Details

### DIFF
--- a/steps/mini-petition/MiniPetition.html
+++ b/steps/mini-petition/MiniPetition.html
@@ -458,7 +458,7 @@
   {% if case.petitionerContactDetailsConfidential == "share" %}
     <h2 class="govuk-heading-m">{{ content.applicantsCorrespondenceAddress }}</h2>
 
-    {% if case.petitionersSolicitorName != "" and not(case.petitionerHomeAddress|length) %}
+    {% if case.petitionersSolicitorName != "" and not(case.petitionerHomeAddress | length) %}
       <p class="govuk-body">{{ case.petitionersSolicitorName }}</p>
       <p class="govuk-body">{{ case.petitionersSolicitorFirm }}</p>
       <p class="govuk-body">{{ case.petitionersSolicitorAddress }}</p>
@@ -471,9 +471,13 @@
   <!-- Respondent Address -->
   {% if case.respondentContactDetailsConfidential == "share" %}
     <h2 class="govuk-heading-m">{{ content.respondentsCorrespondenceAddress }}</h2>
-    {% if case.respondentSolicitorAddress|length %}
-      <p class="govuk-body">{{ case.respondentSolicitorName }}</p>
-      <p class="govuk-body">{{ case.respondentSolicitorCompany }}</p>
+    {% if case.respondentSolicitorAddress | defined %}
+      {% if case.respondentSolicitorName != "" %}
+        <p class="govuk-body">{{ case.respondentSolicitorName }}</p>
+      {% endif %}
+      {% if case.respondentSolicitorCompany != "" %}
+        <p class="govuk-body">{{ case.respondentSolicitorCompany }}</p>
+      {% endif %}
       <p class="govuk-body">{{ case.respondentSolicitorAddress.address | address | safe }}</p>
     {% else %}
       <p class="govuk-body">{{ case.respondentCorrespondenceAddress.address | address | safe }}</p>

--- a/steps/mini-petition/MiniPetition.html
+++ b/steps/mini-petition/MiniPetition.html
@@ -472,10 +472,10 @@
   {% if case.respondentContactDetailsConfidential == "share" %}
     <h2 class="govuk-heading-m">{{ content.respondentsCorrespondenceAddress }}</h2>
     {% if case.respondentSolicitorAddress | defined %}
-      {% if case.respondentSolicitorName != "" %}
+      {% if case.respondentSolicitorName %}
         <p class="govuk-body">{{ case.respondentSolicitorName }}</p>
       {% endif %}
-      {% if case.respondentSolicitorCompany != "" %}
+      {% if case.respondentSolicitorCompany %}
         <p class="govuk-body">{{ case.respondentSolicitorCompany }}</p>
       {% endif %}
       <p class="govuk-body">{{ case.respondentSolicitorAddress.address | address | safe }}</p>

--- a/test/unit/steps/miniPetition.test.js
+++ b/test/unit/steps/miniPetition.test.js
@@ -1273,6 +1273,56 @@ describe(modulePath, () => {
         });
     });
 
+    it('shows respondent solicitors address if available with no solicitor name and firm', () => {
+      const respondentSolicitorAddress = {
+        address: 'Res Solicitors Address'
+      };
+      const session = {
+        case: {
+          data: {
+            connections: {},
+            respondentSolicitorAddress,
+            respondentContactDetailsConfidential: 'share'
+          }
+        }
+      };
+      return content(
+        MiniPetition,
+        session,
+        {
+          specificValues: [ respondentSolicitorAddress.address ]
+        });
+    });
+
+    it('does not show respondent solicitor details if empty address', () => {
+      const respondentSolicitorName = 'Res Solicitor';
+      const respondentSolicitorCompany = 'Res Solicitors Firm';
+      const respondentSolicitorAddress = {
+        address: undefined
+      };
+      const session = {
+        case: {
+          data: {
+            connections: {},
+            respondentSolicitorName,
+            respondentSolicitorCompany,
+            respondentSolicitorAddress,
+            respondentContactDetailsConfidential: 'share'
+          }
+        }
+      };
+      return content(
+        MiniPetition,
+        session,
+        {
+          specificContentToNotExist: [
+            respondentSolicitorName,
+            respondentSolicitorCompany,
+            respondentSolicitorAddress.address
+          ]
+        });
+    });
+
     it('shows respondent address if available', () => {
       const respondentCorrespondenceAddress = {
         address: 'Respondents Address'

--- a/test/unit/views/filters/defined.test.js
+++ b/test/unit/views/filters/defined.test.js
@@ -1,0 +1,76 @@
+const modulePath = 'views/filters/defined';
+
+const { expect } = require('@hmcts/one-per-page-test-suite');
+const filter = require(modulePath);
+
+describe(modulePath, () => {
+  it('should return true when input is valid', () => {
+    const input = 'valid';
+    expect(filter.defined(input)).to.eql(true);
+  });
+
+  it('should return false when input is false', () => {
+    const input = false;
+    expect(filter.defined(input)).to.eql(false);
+  });
+
+  it('should return false when input is null', () => {
+    const input = null;
+    expect(filter.defined(input)).to.eql(false);
+  });
+
+  it('should return false when input is undefined', () => {
+    const input = undefined;
+    expect(filter.defined(input)).to.eql(false);
+  });
+
+  it('should return false when input is empty', () => {
+    const input = '';
+    expect(filter.defined(input)).to.eql(false);
+  });
+
+  it('should return false when input is empty object', () => {
+    const input = {};
+    expect(filter.defined(input)).to.eql(false);
+  });
+
+  it('should return true when input is object with values', () => {
+    const input = {
+      one: 'hello',
+      two: 'world'
+    };
+    expect(filter.defined(input)).to.eql(true);
+  });
+
+  it('should return true when input is object with at least 1 value', () => {
+    const input = {
+      one: false,
+      two: undefined,
+      three: false,
+      four: 'some value'
+    };
+    expect(filter.defined(input)).to.eql(true);
+  });
+
+  it('should return false when input is object with no values', () => {
+    const input = {
+      one: '',
+      two: null,
+      three: undefined,
+      four: false,
+      five: 0
+    };
+    expect(filter.defined(input)).to.eql(false);
+  });
+
+  it('should return false when input is object with no values', () => {
+    const input = {
+      one: '',
+      two: null,
+      three: undefined,
+      four: false,
+      five: 0
+    };
+    expect(filter.defined(input)).to.eql(false);
+  });
+});

--- a/views/filters/defined.js
+++ b/views/filters/defined.js
@@ -1,0 +1,11 @@
+const defined = input => {
+  if (input !== null && typeof input === 'object') {
+    return Object.values(input).some(el => {
+      return Boolean(el);
+    });
+  }
+
+  return Boolean(input);
+};
+
+module.exports.defined = defined;


### PR DESCRIPTION
A bug occurred on Decree Nisi for the Respondent section of the Mini Petition, where the backend CCD to Divorce Frontend Mapper maps the missing Respondent Address to an empty value object. However, this object still matched the condition of length > 0 despite having properties with only null or undefined values. This meant the page crashed at trying to render the RespondentSolicitorName as there is no 'safe' filter on that variable.
It seems as though setting the Respondent Solicitor Name is actually an Optional field on RFE, so the rendering for that and the Firm name are now in their own conditional blocks. The address is now run through a 'defined' filter which returns a truthy if any property in the object is not null or not undefined, and used as the main condition for the entire Respondent Solicitor block of content.

https://tools.hmcts.net/jira/browse/DIV-5927

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
