### PR TITLE
Bump chart

### DIFF
--- a/charts/div-dn/Chart.yaml
+++ b/charts/div-dn/Chart.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 description: Divorce - Decree Nisi
 name: div-dn
-version: 1.1.2
+version: 1.2.0


### PR DESCRIPTION
Last change didn't involve bumping of chart causing 504s 
https://github.com/hmcts/div-decree-nisi-frontend/commit/f2a7634234f3d4e73f2bd83d7671ff398452246f

so, ORCHESTRATION_SERVICE_AMEND_DN_REJECTION_URL is pointing to localhost url