### PR TITLE
DIV-6230: Adding deemed and dispensed approved sections on progress bar page

### DIFF
--- a/mocks/steps/modify-session/ModifySession.content.json
+++ b/mocks/steps/modify-session/ModifySession.content.json
@@ -26,6 +26,16 @@
           "yes": "Yes",
           "no": "No"
         },
+        "serviceApplicationType": {
+          "title": "Service application type",
+          "deemed": "Deemed",
+          "dispensed": "Dispensed"
+        },
+        "serviceApplicationGranted": {
+          "title": "Service Application Granted",
+          "yes": "Yes",
+          "no": "No"
+        },
         "reasonForDivorceBehaviourDetails": {
           "title": "Specify the unreasonable behaviour details"
         },
@@ -82,6 +92,16 @@
         },
         "claimCosts": {
           "title": "[CY] Do you want to claim costs?",
+          "yes": "[CY] Yes",
+          "no": "[CY] No"
+        },
+        "serviceApplicationType": {
+          "title": "[CY] Service application type",
+          "deemed": "[CY] Deemed",
+          "dispensed": "[CY] Dispensed"
+        },
+        "serviceApplicationGranted": {
+          "title": "[CY] Service Application Granted",
           "yes": "[CY] Yes",
           "no": "[CY] No"
         },

--- a/mocks/steps/modify-session/ModifySession.step.js
+++ b/mocks/steps/modify-session/ModifySession.step.js
@@ -73,6 +73,9 @@ class ModifySession extends Question {
     const refusalRejectionReason = list(text);
     const refusalRejectionAdditionalInfo = text;
 
+    const serviceApplicationGranted = text;
+    const serviceApplicationType = text;
+
     return form({
       divorceWho,
       reasonForDivorce,
@@ -100,7 +103,9 @@ class ModifySession extends Question {
       refusalClarificationReason,
       refusalClarificationAdditionalInfo,
       refusalRejectionReason,
-      refusalRejectionAdditionalInfo
+      refusalRejectionAdditionalInfo,
+      serviceApplicationGranted,
+      serviceApplicationType
     });
   }
 

--- a/mocks/steps/modify-session/sections/petitioner.html
+++ b/mocks/steps/modify-session/sections/petitioner.html
@@ -39,6 +39,24 @@
   hideQuestion = false,
   inline = true
 ) }}
+
+  {{ selectionButtons(fields.serviceApplicationType, content.fields.petitioner.serviceApplicationType.title,
+    options = [
+      { label: content.fields.petitioner.serviceApplicationType.deemed, value: "deemed" },
+      { label: content.fields.petitioner.serviceApplicationType.dispensed, value: "dispensed" }
+    ],
+    hideQuestion = false,
+    inline = true
+  ) }}
+
+  {{ selectionButtons(fields.serviceApplicationGranted, content.fields.petitioner.serviceApplicationGranted.title,
+    options = [
+      { label: content.fields.petitioner.serviceApplicationGranted.yes, value: "Yes" },
+      { label: content.fields.petitioner.serviceApplicationGranted.no, value: "No" }
+    ],
+    hideQuestion = false,
+    inline = true
+  ) }}
 {% endcall %}
 
 <div class="js-hidden" id="reason-adultery-container">

--- a/steps/petition-progress-bar/PetitionProgressBar.step.js
+++ b/steps/petition-progress-bar/PetitionProgressBar.step.js
@@ -170,7 +170,22 @@ class PetitionProgressBar extends Interstitial {
   }
 
   get dnReason() {
+    const serviceApplicationReason = this.serviceApplicationReason;
+    if (serviceApplicationReason) {
+      return serviceApplicationReason;
+    }
     return this.case.permittedDecreeNisiReason ? this.case.permittedDecreeNisiReason : constants.undefendedReason;
+  }
+
+  get serviceApplicationReason() {
+    if (this.case.serviceApplicationGranted === 'Yes') {
+      switch (this.case.serviceApplicationType) {
+      case 'deemed': return '5';
+      case 'dispensed': return '6';
+      default: return null;
+      }
+    }
+    return null;
   }
 
   get stateTemplate() {

--- a/steps/petition-progress-bar/petitionerStateTemplates.js
+++ b/steps/petition-progress-bar/petitionerStateTemplates.js
@@ -79,7 +79,9 @@ const permitDNReasonMap = new Map([
   ['1', './sections/deemedService/PetitionProgressBar.deemedService.template.html'],
   ['2', './sections/dispensedWithService/PetitionProgressBar.dispensedWithService.template.html'],
   ['3', './sections/defendedWithoutAnswer/PetitionProgressBar.defendedWithoutAnswer.template.html'],
-  ['4', './sections/defendedWithoutAnswer/PetitionProgressBar.defendedWithoutAnswer.template.html']
+  ['4', './sections/defendedWithoutAnswer/PetitionProgressBar.defendedWithoutAnswer.template.html'],
+  ['5', './sections/deemedApproved/PetitionProgressBar.deemedApproved.template.html'],
+  ['6', './sections/dispensedApproved/PetitionProgressBar.dispensedApproved.template.html']
 ]);
 
 module.exports = {

--- a/steps/petition-progress-bar/sections/deemedApproved/PetitionProgressBar.content.deemedApproved.json
+++ b/steps/petition-progress-bar/sections/deemedApproved/PetitionProgressBar.content.deemedApproved.json
@@ -1,0 +1,12 @@
+{
+  "en": {
+    "deemedApprovedAppStatusMsg": "Your ‘deemed service’ application has been approved",
+    "deemedApprovedAppStatusMsgDetails1": "The court has accepted your application for 'deemed service' that your {{ divorceWho }} received the divorce application.",
+    "deemedApprovedAppStatusMsgDetails2": "You can now continue with the next stage and apply for a decree nisi."
+  },
+  "cy": {
+    "deemedApprovedAppStatusMsg": "Your ‘deemed service’ application has been approved",
+    "deemedApprovedAppStatusMsgDetails1": "The court has accepted your application for 'deemed service' that your {{ divorceWho }} received the divorce application.",
+    "deemedApprovedAppStatusMsgDetails2": "You can now continue with the next stage and apply for a decree nisi."
+  }
+}

--- a/steps/petition-progress-bar/sections/deemedApproved/PetitionProgressBar.deemedApproved.template.html
+++ b/steps/petition-progress-bar/sections/deemedApproved/PetitionProgressBar.deemedApproved.template.html
@@ -1,0 +1,29 @@
+{% from "look-and-feel/components/progress-list.njk" import progressList %}
+
+{{
+progressList({
+one: {
+label: content.youApply,
+complete: true
+},
+two: {
+label: content.husbandWifeMustRespond,
+complete: true
+},
+three: {
+label: content.getDecreeNisi,
+current: true
+},
+four: {
+label: content.madeFinal
+}
+})
+}}
+
+<h2 class="govuk-heading-m">{{ content.deemedApprovedAppStatusMsg }}</h2>
+<p class="govuk-body">{{ content.deemedApprovedAppStatusMsgDetails1 }}</p>
+<p class="govuk-body">{{ content.deemedApprovedAppStatusMsgDetails2 }}</p>
+
+<form action="{{ postUrl | default(path if path else url) }}" method="post" class="form">
+  <input role="button" draggable="false" class="govuk-button govuk-button--start" type="submit" value="{{ content.continue }}">
+</form>

--- a/steps/petition-progress-bar/sections/dispensedApproved/PetitionProgressBar.content.dispensedApproved.json
+++ b/steps/petition-progress-bar/sections/dispensedApproved/PetitionProgressBar.content.dispensedApproved.json
@@ -1,0 +1,12 @@
+{
+  "en": {
+    "dispensedApprovedAppStatusMsg": "Your ‘dispense with service’ application has been approved",
+    "dispensedApprovedAppStatusMsgDetails1": "The court has accepted your application to 'dispense with service' and that your {{ divorceWho }} doesn’t have to be served the divorce application.",
+    "dispensedApprovedAppStatusMsgDetails2": "You can now continue with the next stage and apply for a decree nisi."
+  },
+  "cy": {
+    "dispensedApprovedAppStatusMsg": "Your ‘dispense with service’ application has been approved",
+    "dispensedApprovedAppStatusMsgDetails1": "The court has accepted your application to 'dispense with service' and that your {{ divorceWho }} doesn’t have to be served the divorce application.",
+    "dispensedApprovedAppStatusMsgDetails2": "You can now continue with the next stage and apply for a decree nisi."
+  }
+}

--- a/steps/petition-progress-bar/sections/dispensedApproved/PetitionProgressBar.dispensedApproved.template.html
+++ b/steps/petition-progress-bar/sections/dispensedApproved/PetitionProgressBar.dispensedApproved.template.html
@@ -1,0 +1,29 @@
+{% from "look-and-feel/components/progress-list.njk" import progressList %}
+
+{{
+progressList({
+one: {
+label: content.youApply,
+complete: true
+},
+two: {
+label: content.husbandWifeMustRespond,
+complete: true
+},
+three: {
+label: content.getDecreeNisi,
+current: true
+},
+four: {
+label: content.madeFinal
+}
+})
+}}
+
+<h2 class="govuk-heading-m">{{ content.dispensedApprovedAppStatusMsg }}</h2>
+<p class="govuk-body">{{ content.dispensedApprovedAppStatusMsgDetails1 }}</p>
+<p class="govuk-body">{{ content.dispensedApprovedAppStatusMsgDetails2 }}</p>
+
+<form action="{{ postUrl | default(path if path else url) }}" method="post" class="form">
+  <input role="button" draggable="false" class="govuk-button govuk-button--start" type="submit" value="{{ content.continue }}">
+</form>

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -47,7 +47,11 @@ const templates = {
   awaitingClarification:
     './sections/awaitingClarification/PetitionProgressBar.awaitingClarification.template.html',
   dnIsRefused:
-    './sections/dnIsRefused/PetitionProgressBar.dnIsRefused.template.html'
+    './sections/dnIsRefused/PetitionProgressBar.dnIsRefused.template.html',
+  deemedApproved:
+    './sections/deemedApproved/PetitionProgressBar.deemedApproved.template.html',
+  dispensedApproved:
+    './sections/dispensedApproved/PetitionProgressBar.dispensedApproved.template.html'
 };
 
 // get all content for all pages
@@ -417,6 +421,54 @@ describe(modulePath, () => {
     it('renders the correct template', () => {
       const instance = stepAsInstance(PetitionProgressBar, session);
       expect(instance.stateTemplate).to.eql(templates.defendedWithoutAnswer);
+    });
+  });
+
+  describe('CCD state: DNawaiting, ServiceApplicationType: deemed, ServiceApplicationGranted: Yes, DNReason : 5', () => {
+    const session = {
+      case: {
+        state: 'AwaitingDecreeNisi',
+        data: {
+          serviceApplicationType: 'deemed',
+          serviceApplicationGranted: 'Yes'
+        }
+      }
+    };
+
+    it('renders the correct content', () => {
+      const specificContent = Object.keys(pageContent.deemedApproved);
+      const specificContentToNotExist = contentToNotExist('deemedApproved');
+
+      return content(PetitionProgressBar, session, { specificContent, specificContentToNotExist });
+    });
+
+    it('renders the correct template', () => {
+      const instance = stepAsInstance(PetitionProgressBar, session);
+      expect(instance.stateTemplate).to.eql(templates.deemedApproved);
+    });
+  });
+
+  describe('CCD state: DNawaiting, ServiceApplicationType: dispensed, ServiceApplicationGranted: Yes, DNReason : 6', () => {
+    const session = {
+      case: {
+        state: 'AwaitingDecreeNisi',
+        data: {
+          serviceApplicationType: 'dispensed',
+          serviceApplicationGranted: 'Yes'
+        }
+      }
+    };
+
+    it('renders the correct content', () => {
+      const specificContent = Object.keys(pageContent.dispensedApproved);
+      const specificContentToNotExist = contentToNotExist('dispensedApproved');
+
+      return content(PetitionProgressBar, session, { specificContent, specificContentToNotExist });
+    });
+
+    it('renders the correct template', () => {
+      const instance = stepAsInstance(PetitionProgressBar, session);
+      expect(instance.stateTemplate).to.eql(templates.dispensedApproved);
     });
   });
 


### PR DESCRIPTION

# Description

Adding deemed and dispensed approved sections on progress bar page, so that those sections are displayed when a case has ServiceApplicationGranted equal to yes and ServiceApplicationType equal to 'deemed' or 'dispensed'.

Fixes https://tools.hmcts.net/jira/browse/DIV-6230

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
