### PR TITLE
DIV-6179-Served-by-process-server-update-DN-landing-page

### DIFF
--- a/mocks/steps/modify-session/ModifySession.content.json
+++ b/mocks/steps/modify-session/ModifySession.content.json
@@ -36,6 +36,11 @@
           "yes": "Yes",
           "no": "No"
         },
+        "servedByProcessServer": {
+          "title": "Served by process server",
+          "yes": "Yes",
+          "no": "No"
+        },
         "reasonForDivorceBehaviourDetails": {
           "title": "Specify the unreasonable behaviour details"
         },
@@ -58,6 +63,11 @@
         },
         "respLegalProceedingsDescription": {
           "title": "Details of the court cases?"
+        },
+        "receivedAOSfromResp": {
+          "title": "AOS Received from Respondent",
+          "yes": "Yes",
+          "no": "No"
         },
         "respCostsReason": {
           "title": "Provide a brief explanation of why you should not pay?"
@@ -105,6 +115,16 @@
           "yes": "[CY] Yes",
           "no": "[CY] No"
         },
+        "servedByProcessServer": {
+          "title": "[CY] Served by process server",
+          "yes": "[CY] Yes",
+          "no": "[CY] No"
+        },
+        "receivedAOSfromResp": {
+          "title": "[CY] AOS Received from Respondent",
+          "yes": "[CY] Yes",
+          "no": "[CY] No"
+        },
         "reasonForDivorceBehaviourDetails": {
           "title": "[CY] Specify the unreasonable behaviour details"
         },
@@ -127,6 +147,11 @@
         },
         "respLegalProceedingsDescription": {
           "title": "[CY] Details of the court cases?"
+        },
+        "receivedAOSfromResp": {
+          "title": "[CY] AOS Received from Respondent",
+          "yes": "[CY] Yes",
+          "no": "[CY] No"
         },
         "respCostsReason": {
           "title": "[CY] Provide a brief explanation of why you should not pay?"

--- a/mocks/steps/modify-session/ModifySession.step.js
+++ b/mocks/steps/modify-session/ModifySession.step.js
@@ -76,6 +76,9 @@ class ModifySession extends Question {
     const serviceApplicationGranted = text;
     const serviceApplicationType = text;
 
+    const servedByProcessServer = text;
+    const receivedAOSfromResp = text;
+
     return form({
       divorceWho,
       reasonForDivorce,
@@ -105,7 +108,9 @@ class ModifySession extends Question {
       refusalRejectionReason,
       refusalRejectionAdditionalInfo,
       serviceApplicationGranted,
-      serviceApplicationType
+      serviceApplicationType,
+      servedByProcessServer,
+      receivedAOSfromResp
     });
   }
 

--- a/mocks/steps/modify-session/sections/petitioner.html
+++ b/mocks/steps/modify-session/sections/petitioner.html
@@ -57,6 +57,15 @@
     hideQuestion = false,
     inline = true
   ) }}
+
+  {{ selectionButtons(fields.servedByProcessServer, content.fields.petitioner.servedByProcessServer.title,
+    options = [
+      { label: content.fields.petitioner.servedByProcessServer.yes, value: "Yes" },
+      { label: content.fields.petitioner.servedByProcessServer.no, value: "No" }
+    ],
+    hideQuestion = false,
+    inline = true
+  ) }}
 {% endcall %}
 
 <div class="js-hidden" id="reason-adultery-container">

--- a/mocks/steps/modify-session/sections/respondent.html
+++ b/mocks/steps/modify-session/sections/respondent.html
@@ -10,6 +10,15 @@
     inline = true
   ) }}
 
+  {{ selectionButtons(fields.receivedAOSfromResp, content.fields.respondent.receivedAOSfromResp.title,
+    options = [
+      { label: content.fields.respondent.receivedAOSfromResp.yes, value: "Yes" },
+      { label: content.fields.respondent.receivedAOSfromResp.no, value: "No" }
+    ],
+    hideQuestion = false,
+    inline = true
+  ) }}
+
   <div class="js-hidden" id="costOrder-yes-container">
     {{ selectionButtons(fields.whoPaysCosts, "Who pays costs?",
       options = [

--- a/steps/petition-progress-bar/petitionerStateTemplates.js
+++ b/steps/petition-progress-bar/petitionerStateTemplates.js
@@ -81,12 +81,20 @@ const permitDNReasonMap = new Map([
   ['3', './sections/defendedWithoutAnswer/PetitionProgressBar.defendedWithoutAnswer.template.html'],
   ['4', './sections/defendedWithoutAnswer/PetitionProgressBar.defendedWithoutAnswer.template.html'],
   ['5', './sections/deemedApproved/PetitionProgressBar.deemedApproved.template.html'],
-  ['6', './sections/dispensedApproved/PetitionProgressBar.dispensedApproved.template.html']
+  ['6', './sections/dispensedApproved/PetitionProgressBar.dispensedApproved.template.html'],
+  ['7', './sections/processServerService/PetitionProgressBar.processServerService.template.html']
 ]);
+
+const dnAwaitingTemplate = {
+  deemed: '5',
+  dispensed: '6',
+  servedByProcessServer: '7'
+};
 
 module.exports = {
   caseStateMap,
   permitDNReasonMap,
   caseIdDisplayStateMap,
-  awaitingPronouncementWithHearingDateTemplate
+  awaitingPronouncementWithHearingDateTemplate,
+  dnAwaitingTemplate
 };

--- a/steps/petition-progress-bar/sections/processServerService/PetitionProgressBar.content.processServerService.json
+++ b/steps/petition-progress-bar/sections/processServerService/PetitionProgressBar.content.processServerService.json
@@ -1,0 +1,12 @@
+{
+  "en": {
+    "processServerServiceHeader": "Your divorce petition has been served by a process server",
+    "processServerServiceResponseInfo": "Your {{ divorceWho }} was served using a process server. However, they have not yet responded.",
+    "processServerServiceDetails": "Because it is more than 7 days since service, you are now able continue to the next stage and apply for a decree nisi."
+  },
+  "cy": {
+    "processServerServiceHeader": "[CY] Your divorce petition has been served by a process server",
+    "processServerServiceResponseInfo": "[CY] Your {{ divorceWho }} was served using a process server. However, they have not yet responded.",
+    "processServerServiceDetails": "[CY] Because it is more than 7 days since service, you are now able continue to the next stage and apply for a decree nisi."
+  }
+}

--- a/steps/petition-progress-bar/sections/processServerService/PetitionProgressBar.processServerService.template.html
+++ b/steps/petition-progress-bar/sections/processServerService/PetitionProgressBar.processServerService.template.html
@@ -1,0 +1,31 @@
+{% from "look-and-feel/components/progress-list.njk" import progressList %}
+
+{{
+  progressList({
+    one: {
+      label: content.youApply,
+      complete: true
+    },
+    two: {
+      label: content.husbandWifeMustRespond,
+      complete: true
+    },
+    three: {
+      label: content.getDecreeNisi,
+      current: true
+    },
+    four: {
+      label: content.madeFinal
+    }
+  })
+}}
+
+<h2 class="govuk-heading-m">{{ content.processServerServiceHeader }}</h2>
+
+<p class="govuk-body">{{ content.processServerServiceResponseInfo }}</p>
+
+<p class="govuk-body">{{ content.processServerServiceDetails }}</p>
+
+<form action="{{ postUrl | default(path if path else url) }}" method="post" class="form">
+  <input role="button" draggable="false" class="govuk-button govuk-button--start" type="submit" value="{{ content.continue }}">
+</form>

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -8,13 +8,17 @@ const DnNoResponse = require('steps/dn-no-response/DnNoResponse.step');
 const ReviewAosResponse = require('steps/review-aos-response/ReviewAosResponse.step');
 const ApplyForDecreeNisi = require('steps/apply-for-decree-nisi/ApplyForDecreeNisi.step');
 const idam = require('services/idam');
-const { custom, middleware, interstitial, sinon, content,
-  stepAsInstance, expect } = require('@hmcts/one-per-page-test-suite');
+const {
+  custom, middleware, interstitial, sinon, content,
+  stepAsInstance, expect
+} = require('@hmcts/one-per-page-test-suite');
 const checkCaseState = require('middleware/checkCaseState');
 const httpStatus = require('http-status-codes');
 const glob = require('glob');
-const { getExpectedCourtsList, testDivorceUnitDetailsRender,
-  testCTSCDetailsRender } = require('test/unit/helpers/courtInformation');
+const {
+  getExpectedCourtsList, testDivorceUnitDetailsRender,
+  testCTSCDetailsRender
+} = require('test/unit/helpers/courtInformation');
 const caseOrchestrationService = require('services/caseOrchestrationService');
 const redirectToFrontendHelper = require('helpers/redirectToFrontendHelper');
 
@@ -51,7 +55,9 @@ const templates = {
   deemedApproved:
     './sections/deemedApproved/PetitionProgressBar.deemedApproved.template.html',
   dispensedApproved:
-    './sections/dispensedApproved/PetitionProgressBar.dispensedApproved.template.html'
+    './sections/dispensedApproved/PetitionProgressBar.dispensedApproved.template.html',
+  processServerService:
+    './sections/processServerService/PetitionProgressBar.processServerService.template.html'
 };
 
 // get all content for all pages
@@ -141,7 +147,7 @@ describe(modulePath, () => {
     });
 
     it('displays case id', () => {
-      return content(PetitionProgressBar, session, { specificValues: [ referenceNumber ] });
+      return content(PetitionProgressBar, session, { specificValues: [referenceNumber] });
     });
   });
 
@@ -171,12 +177,12 @@ describe(modulePath, () => {
         PetitionProgressBar,
         session,
         {
-          specificValues: [ session.case.data.caseReference ]
+          specificValues: [session.case.data.caseReference]
         });
     });
   });
 
-  describe('CCD state: DNawaiting, DNReason : 0 ', () => {
+  describe('CCD state: AwaitingDecreeNisi, DNReason : 0 ', () => {
     const session = {
       case: {
         state: 'AwaitingDecreeNisi',
@@ -273,8 +279,7 @@ describe(modulePath, () => {
     });
   });
 
-
-  describe('CCD state: DNawaiting, DNReason : 1 ', () => {
+  describe('CCD state: AwaitingDecreeNisi, DNReason : 1 ', () => {
     const session = {
       case: {
         state: 'AwaitingDecreeNisi',
@@ -326,7 +331,7 @@ describe(modulePath, () => {
     });
   });
 
-  describe('CCD state: DNawaiting, DNReason : 2 ', () => {
+  describe('CCD state: AwaitingDecreeNisi, DNReason : 2 ', () => {
     const session = {
       case: {
         state: 'AwaitingDecreeNisi',
@@ -378,7 +383,7 @@ describe(modulePath, () => {
     });
   });
 
-  describe('CCD state: DNawaiting, DNReason : 3 ', () => {
+  describe('CCD state: AwaitingDecreeNisi, DNReason : 3 ', () => {
     const session = {
       case: {
         state: 'AwaitingDecreeNisi',
@@ -401,7 +406,7 @@ describe(modulePath, () => {
     });
   });
 
-  describe('CCD state: DNawaiting, DNReason : 4 ', () => {
+  describe('CCD state: AwaitingDecreeNisi, DNReason : 4 ', () => {
     const session = {
       case: {
         state: 'AwaitingDecreeNisi',
@@ -424,7 +429,7 @@ describe(modulePath, () => {
     });
   });
 
-  describe('CCD state: DNawaiting, ServiceApplicationType: deemed, ServiceApplicationGranted: Yes, DNReason : 5', () => {
+  describe('CCD state: AwaitingDecreeNisi, ServiceApplicationType: deemed, ServiceApplicationGranted: Yes, DNReason : 5', () => {
     const session = {
       case: {
         state: 'AwaitingDecreeNisi',
@@ -448,7 +453,7 @@ describe(modulePath, () => {
     });
   });
 
-  describe('CCD state: DNawaiting, ServiceApplicationType: dispensed, ServiceApplicationGranted: Yes, DNReason : 6', () => {
+  describe('CCD state: AwaitingDecreeNisi, ServiceApplicationType: dispensed, ServiceApplicationGranted: Yes, DNReason : 6', () => {
     const session = {
       case: {
         state: 'AwaitingDecreeNisi',
@@ -469,6 +474,68 @@ describe(modulePath, () => {
     it('renders the correct template', () => {
       const instance = stepAsInstance(PetitionProgressBar, session);
       expect(instance.stateTemplate).to.eql(templates.dispensedApproved);
+    });
+  });
+
+  describe('CCD state: AwaitingDecreeNisi, Served by process server, ProcessServer: Yes, DNReason : 7', () => {
+    let session = {};
+    let petitionProgressBar = {};
+
+    before(() => {
+      session = {
+        case: {
+          state: 'AwaitingDecreeNisi',
+          data: {
+            servedByProcessServer: 'Yes',
+            receivedAOSfromResp: 'No',
+            permittedDecreeNisiReason: '3'
+          }
+        }
+      };
+      petitionProgressBar = stepAsInstance(PetitionProgressBar, session);
+    });
+
+    describe('Content Rendering for Process Server', () => {
+      it('should render the process server service template', () => {
+        expect(petitionProgressBar.stateTemplate).to.equal(templates.processServerService);
+      });
+
+      it('should render the correct content', () => {
+        const specificContent = Object.keys(pageContent.processServerService);
+        return content(PetitionProgressBar, session, { specificContent });
+      });
+
+      it('should render the default decree nisi template', () => {
+        session = {
+          case: {
+            state: 'AwaitingDecreeNisi',
+            data: {
+              servedByProcessServer: 'No',
+              receivedAOSfromResp: 'Yes',
+              permittedDecreeNisiReason: '3'
+            }
+          }
+        };
+
+        const progressBarInstance = stepAsInstance(PetitionProgressBar, session);
+        expect(progressBarInstance.stateTemplate).to.equal(templates.defendedWithoutAnswer);
+      });
+    });
+
+    describe('Process Server functionality', () => {
+      it('should return true if process server is served and no response from respondent', () => {
+        expect(petitionProgressBar.isAwaitingDecreeNisiWithProcessServerService()).to.equal(true);
+      });
+
+      it('should return true if case is awaiting decree nisi', () => {
+        expect(petitionProgressBar.isAwaitingDecreeNisi()).to.equal(true);
+      });
+
+      it('should return false if case is not awaiting decree nisi', () => {
+        session.case.state = 'AOSOverdue';
+        const instance = stepAsInstance(PetitionProgressBar, session);
+        expect(instance.isAwaitingDecreeNisi()).to.equal(false);
+      });
     });
   });
 
@@ -871,7 +938,7 @@ describe(modulePath, () => {
       case: {
         state: 'AwaitingPronouncement',
         data: {
-          hearingDate: [ '2018-04-25T00:00:00.000Z' ],
+          hearingDate: ['2018-04-25T00:00:00.000Z'],
           d8: [
             {
               id: '401ab79e-34cb-4570-9f2f-4cf9357m4st3r',
@@ -915,7 +982,7 @@ describe(modulePath, () => {
         case: {
           state: 'AwaitingPronouncement',
           data: {
-            hearingDate: [ '2018-04-25T00:00:00.000Z' ]
+            hearingDate: ['2018-04-25T00:00:00.000Z']
           }
         }
       };
@@ -1057,8 +1124,8 @@ describe(modulePath, () => {
             refusalClarificationAdditionalInfo: 'some extra info',
             dnOutcomeCase: true
           };
-          const specificContent = [ 'clarificationCourtFeedback.other.title' ];
-          const specificValues = [ 'some extra info' ];
+          const specificContent = ['clarificationCourtFeedback.other.title'];
+          const specificValues = ['some extra info'];
           return content(PetitionProgressBar, session, { specificContent, specificValues });
         });
       });
@@ -1088,7 +1155,7 @@ describe(modulePath, () => {
     });
   });
 
-  describe('CCD state: DNisRefused', () => {
+  describe('CCD state: DecreeNisiIsRefused', () => {
     let sandbox = {};
 
     before(() => {
@@ -1175,8 +1242,8 @@ describe(modulePath, () => {
             refusalRejectionAdditionalInfo: 'some extra info',
             dnOutcomeCase: true
           };
-          const specificContent = [ 'dnIsRefusedRefusalCourtFeedback.other.title' ];
-          const specificValues = [ 'some extra info' ];
+          const specificContent = ['dnIsRefusedRefusalCourtFeedback.other.title'];
+          const specificValues = ['some extra info'];
           return content(PetitionProgressBar, session, { specificContent, specificValues });
         });
       });
@@ -1329,7 +1396,7 @@ describe(modulePath, () => {
     });
   });
 
-  describe('CCD state: DNPronounced', () => {
+  describe('CCD state: DecreeNisiPronounced', () => {
     let session = {};
 
     beforeEach(() => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -2359,7 +2359,7 @@ bindings@^1.5.0:
   dependencies:
     file-uri-to-path "1.0.0"
 
-"bl@ >=1.2.3 <2.0.0 || >=4.0.3", bl@^1.0.0, bl@^4.0.1:
+bl@>=4.0.3, bl@^1.0.0, bl@^4.0.1:
   version "4.0.3"
   resolved "https://registry.yarnpkg.com/bl/-/bl-4.0.3.tgz#12d6287adc29080e22a705e5764b2a9522cdc489"
   integrity sha512-fs4G6/Hu4/EE+F75J8DuN/0IpQqNjAdC7aEQv7Qt8MHGUH7Ckv2MwTEEeN9QehD0pfIDkMI1bkHYkKy7xHyKIg==


### PR DESCRIPTION
# Description
https://tools.hmcts.net/jira/browse/DIV-6179

Landing page added to DN for when a case is awaiting decree nisi and has been served by process server service and aos is over due.

New landing page follows similar DNAwaiting screen format and flow

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
