### PR TITLE
Added crossbrowser tests for all browsers

### DIFF
--- a/Jenkinsfile_nightly
+++ b/Jenkinsfile_nightly
@@ -47,6 +47,10 @@ withNightlyPipeline("nodejs", product, component) {
       yarnBuilder.yarn('test:a11y')
     }
 
+  after('crossBrowserTest') {
+     steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'
+  }
+
     after('fullfunctionalTest') {
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'smoke-output/**/*'
       steps.archiveArtifacts allowEmptyArchive: true, artifacts: 'functional-output/**/*'

--- a/config/custom-environment-variables.yml
+++ b/config/custom-environment-variables.yml
@@ -96,6 +96,7 @@ features:
   webchat: FEATURE_WEBCHAT
   awaitingClarification: FEATURE_AWAITING_CLARIFICATION
   dnIsRefused: FEATURE_DN_IS_REFUSED
+  browserSupport: BROWSER_GROUP
 
 ccd:
   courts: CCD_DIGITAL_COURTS

--- a/config/default.yml
+++ b/config/default.yml
@@ -143,6 +143,7 @@ features:
   webchat: true
   awaitingClarification: true
   dnIsRefused: true
+  browserSupport: false
 
 journey:
   timeoutDelay: 300
@@ -182,5 +183,5 @@ saucelabs:
   username: 'username'
   key: 'privatekey'
   tunnelId: 'reformtunnel'
-  waitForTimeout: 20000
-  smartWait: 20000
+  waitForTimeout: 30000
+  smartWait: 30000

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:functional": "NODE_PATH=. LOG_LEVEL=ERROR codeceptjs run -c test/functional/codecept.conf.js --steps --invert --reporter mocha-multi",
     "test:functional:remote": "NODE_PATH=. POINT_TO_REMOTE=true LOG_LEVEL=OFF codeceptjs run -c test/functional/codecept.conf.js --steps --invert",
     "test:crossbrowser": "./bin/run-crossbrowser-tests.sh",
-    "test-crossbrowser-e2e": "NODE_PATH=. NODE_ENV=aat  LOG_LEVEL=ERROR node_modules/.bin/codeceptjs run-multiple  ${BROWSER_GROUP:-'--all'} -c test/functional/saucelabs.conf.js --steps --reporter mocha-multi",
+    "test-crossbrowser-e2e": "NODE_PATH=. NODE_ENV=ci  LOG_LEVEL=ERROR node_modules/.bin/codeceptjs run-multiple  ${BROWSER_GROUP:-'--all'} -c test/functional/saucelabs.conf.js --steps --reporter mocha-multi",
     "test:validation": "NODE_PATH=. NODE_ENV=testing LOG_LEVEL=OFF mocha --exit test/w3cjs",
     "lint": "eslint ."
   },

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "test:functional": "NODE_PATH=. LOG_LEVEL=ERROR codeceptjs run -c test/functional/codecept.conf.js --steps --invert --reporter mocha-multi",
     "test:functional:remote": "NODE_PATH=. POINT_TO_REMOTE=true LOG_LEVEL=OFF codeceptjs run -c test/functional/codecept.conf.js --steps --invert",
     "test:crossbrowser": "./bin/run-crossbrowser-tests.sh",
-    "test-crossbrowser-e2e": "NODE_PATH=. NODE_ENV=ci  LOG_LEVEL=ERROR node_modules/.bin/codeceptjs run-multiple  ${BROWSER_GROUP:-'--all'} -c test/functional/saucelabs.conf.js --steps --reporter mocha-multi",
+    "test-crossbrowser-e2e": "NODE_PATH=. NODE_ENV=aat  LOG_LEVEL=ERROR node_modules/.bin/codeceptjs run-multiple  ${BROWSER_GROUP:-'--all'} -c test/functional/saucelabs.conf.js --steps --reporter mocha-multi",
     "test:validation": "NODE_PATH=. NODE_ENV=testing LOG_LEVEL=OFF mocha --exit test/w3cjs",
     "lint": "eslint ."
   },

--- a/test/crossbrowser/supportedBrowsers.js
+++ b/test/crossbrowser/supportedBrowsers.js
@@ -19,7 +19,8 @@ const supportedBrowsers = {
       platformName: LATEST_WINDOWS,
       browserVersion: 'latest',
       'sauce:options': {
-        name: 'Edge_Win10_DECREE_NISI'
+        name: 'Edge_Win10_DECREE_NISI',
+        screenResolution: '1400x1050'
       }
     }
   },

--- a/test/functional/helpers/JSWait.js
+++ b/test/functional/helpers/JSWait.js
@@ -25,7 +25,7 @@ class JSWait extends codecept_helper { // eslint-disable-line camelcase
     const helper = this.helpers.WebDriver || this.helpers.Puppeteer;
     const helperIsPuppeteer = this.helpers.Puppeteer;
 
-    helper.click(text, locator);
+    await helper.click(text, locator);
 
     if (helperIsPuppeteer) {
       await helper.page.waitForNavigation({ waitUntil: 'networkidle0' });

--- a/test/functional/helpers/JSWait.js
+++ b/test/functional/helpers/JSWait.js
@@ -53,7 +53,6 @@ class JSWait extends codecept_helper { // eslint-disable-line camelcase
       await helper.page.waitForNavigation({ waitUntil: 'networkidle0' });
     } else {
       await helper.amOnPage(newUrl);
-      // await helper.waitInUrl(newUrl);
       await helper.waitForElement('body');
     }
   }

--- a/test/functional/helpers/JSWait.js
+++ b/test/functional/helpers/JSWait.js
@@ -25,10 +25,11 @@ class JSWait extends codecept_helper { // eslint-disable-line camelcase
     const helper = this.helpers.WebDriver || this.helpers.Puppeteer;
     const helperIsPuppeteer = this.helpers.Puppeteer;
 
-    helper.click(text, locator);
-
     if (helperIsPuppeteer) {
+      helper.click(text, locator);
       await helper.page.waitForNavigation({ waitUntil: 'networkidle0' });
+    } else {
+      await helper.click(text, locator);
     }
 
     await helper.wait(3);
@@ -53,6 +54,7 @@ class JSWait extends codecept_helper { // eslint-disable-line camelcase
       await helper.page.waitForNavigation({ waitUntil: 'networkidle0' });
     } else {
       await helper.amOnPage(newUrl);
+      await helper.wait(2);
       await helper.waitForElement('body');
     }
   }

--- a/test/functional/helpers/JSWait.js
+++ b/test/functional/helpers/JSWait.js
@@ -25,7 +25,7 @@ class JSWait extends codecept_helper { // eslint-disable-line camelcase
     const helper = this.helpers.WebDriver || this.helpers.Puppeteer;
     const helperIsPuppeteer = this.helpers.Puppeteer;
 
-    await helper.click(text, locator);
+    helper.click(text, locator);
 
     if (helperIsPuppeteer) {
       await helper.page.waitForNavigation({ waitUntil: 'networkidle0' });

--- a/test/functional/helpers/JSWait.js
+++ b/test/functional/helpers/JSWait.js
@@ -53,7 +53,7 @@ class JSWait extends codecept_helper { // eslint-disable-line camelcase
       await helper.page.waitForNavigation({ waitUntil: 'networkidle0' });
     } else {
       await helper.amOnPage(newUrl);
-      await helper.waitInUrl(newUrl);
+      // await helper.waitInUrl(newUrl);
       await helper.waitForElement('body');
     }
   }

--- a/test/functional/helpers/SauceLabsBrowserHelper.js
+++ b/test/functional/helpers/SauceLabsBrowserHelper.js
@@ -1,0 +1,16 @@
+// eslint-disable-next-line camelcase
+const Helper = codecept_helper;
+
+class SauceLabsBrowserHelper extends Helper {
+  async _before() {
+    const webdriver = this.helpers.WebDriver;
+    if (webdriver) {
+      if (webdriver.config.browser === 'internet explorer') {
+        console.log('Increasing IE11 browser window size'); /* eslint-disable-line no-console */
+        await webdriver.browser.setWindowSize(1280, 960);
+      }
+    }
+  }
+}
+
+module.exports = SauceLabsBrowserHelper;

--- a/test/functional/helpers/elementExist.js
+++ b/test/functional/helpers/elementExist.js
@@ -5,14 +5,10 @@ const Helper = codecept_helper; // eslint-disable-line
 class ElementExist extends Helper {
   checkElementExist(selector) {
     const helper = this.helpers.WebDriver || this.helpers.Puppeteer;
-    const isWebDriver = typeof this.helpers.WebDriver !== 'undefined';
 
     return helper
       ._locate(selector)
       .then(els => {
-        if (isWebDriver) {
-          return Boolean(els.value.length);
-        }
         return Boolean(els.length);
       });
   }

--- a/test/functional/helpers/idamHelper.js
+++ b/test/functional/helpers/idamHelper.js
@@ -71,7 +71,7 @@ class IdamHelper extends Helper {
           throw error;
         });
     }
-    return Promise.resolve({});
+    return null;
   }
 
   _after() {

--- a/test/functional/pages/applyForDecreeNisi.js
+++ b/test/functional/pages/applyForDecreeNisi.js
@@ -7,10 +7,10 @@ function testApplyForDecreeNisiPage(language = 'en') {
   const I = this;
 
   I.amOnLoadedPage(ApplyForDecreeNisi.path, language);
-  I.waitInUrl(ApplyForDecreeNisi.path, 5);
+  I.waitInUrl(ApplyForDecreeNisi.path);
   I.retry(2).click(ApplyForDecreeNisiContent[language].fields.applyForDecreeNisi.yes);
   I.navByClick(commonContent[language].continue);
-  I.waitInUrl(MiniPetition.path, 5);
+  I.waitInUrl(MiniPetition.path);
   I.seeCurrentUrlEquals(MiniPetition.path);
 }
 

--- a/test/functional/pages/behaviourContinuedSinceApplication.js
+++ b/test/functional/pages/behaviourContinuedSinceApplication.js
@@ -11,10 +11,10 @@ function testBehaviourContinuedSinceApplicationPage(language = 'en') {
   const I = this;
 
   I.amOnLoadedPage(BehaviourContinuedSinceApplication.path, language);
-  I.waitInUrl(BehaviourContinuedSinceApplication.path, 5);
+  I.waitInUrl(BehaviourContinuedSinceApplication.path);
   I.retry(2).click(BehaviourContinuedSinceApplicationContent[language].fields.changes.behaviourContinuedSinceApplication.yes); // eslint-disable-line
   I.navByClick(commonContent[language].continue);
-  I.waitInUrl(ClaimCosts.path, 5);
+  I.waitInUrl(ClaimCosts.path);
   I.seeCurrentUrlEquals(ClaimCosts.path);
 }
 

--- a/test/functional/pages/claimCosts.js
+++ b/test/functional/pages/claimCosts.js
@@ -13,7 +13,7 @@ function testClaimCostsPage(language = 'en') {
   I.amOnLoadedPage(ClaimCosts.path, language);
   I.click(ClaimCostsContent[language].fields.dnCosts.originalAmount);
   I.navByClick(commonContent[language].continue);
-  I.waitInUrl(ShareCourtDocuments.path, 5);
+  I.waitInUrl(ShareCourtDocuments.path);
   I.seeCurrentUrlEquals(ShareCourtDocuments.path);
 }
 

--- a/test/functional/pages/done.step.js
+++ b/test/functional/pages/done.step.js
@@ -6,6 +6,8 @@ function testDonePage(language = 'en') {
 
   I.amOnLoadedPage(DonePage.path);
 
+  I.waitInUrl(DonePage.path);
+
   I.see(DoneContent[language].applicationComplete);
 }
 

--- a/test/functional/pages/exit.step.js
+++ b/test/functional/pages/exit.step.js
@@ -8,6 +8,8 @@ async function testExitPage(language = 'en') {
 
   I.amOnLoadedPage(ExitPage.path, language);
 
+  I.waitInUrl(ExitPage.path);
+
   I.see(ExitPageContent[language].title);
 }
 

--- a/test/functional/pages/exitIntolerable.step.js
+++ b/test/functional/pages/exitIntolerable.step.js
@@ -8,6 +8,8 @@ async function testExitIntolerable(language = 'en') {
 
   I.amOnLoadedPage(ExitIntolerablePage.path, language);
 
+  I.waitInUrl(ExitIntolerablePage.path);
+
   I.see(ExitIntolerablePageContent[language].contact);
 }
 

--- a/test/functional/pages/idam.step.js
+++ b/test/functional/pages/idam.step.js
@@ -11,6 +11,7 @@ async function testIdamPage(success = true) {
   const currentPath = await I.getCurrentUrl();
   if (currentPath !== PetitionProgressBarPage.path) {
     if (currentPath === IdamMockLogin.path) {
+      I.waitInUrl(IdamMockLogin.path);
       I.seeCurrentUrlEquals(IdamMockLogin.path);
       if (success) {
         I.checkOption(content.en.fields.success.yes);

--- a/test/functional/pages/idam.step.js
+++ b/test/functional/pages/idam.step.js
@@ -6,8 +6,8 @@ const idamConfigHelper = require('test/functional/helpers/idamConfigHelper.js');
 async function testIdamPage(success = true) {
   const I = this;
 
+  I.wait(2);
   I.amOnLoadedPage('/');
-  I.wait(3);
 
   const currentPath = await I.getCurrentUrl();
   if (currentPath !== PetitionProgressBarPage.path) {

--- a/test/functional/pages/idam.step.js
+++ b/test/functional/pages/idam.step.js
@@ -28,7 +28,8 @@ async function testIdamPage(success = true) {
     }
   }
 
-  I.seeCurrentUrlEquals(PetitionProgressBarPage.path);
+  I.wait(3);
+  I.waitInUrl(PetitionProgressBarPage.path);
 }
 
 module.exports = { testIdamPage };

--- a/test/functional/pages/idam.step.js
+++ b/test/functional/pages/idam.step.js
@@ -7,6 +7,7 @@ async function testIdamPage(success = true) {
   const I = this;
 
   I.amOnLoadedPage('/');
+  I.wait(3);
 
   const currentPath = await I.getCurrentUrl();
   if (currentPath !== PetitionProgressBarPage.path) {
@@ -20,6 +21,7 @@ async function testIdamPage(success = true) {
       }
       I.navByClick('Continue');
     } else {
+      I.waitInUrl('/login?');
       await I.seeInCurrentUrl('/login?');
       I.fillField('username', idamConfigHelper.getTestEmail());
       I.fillField('password', idamConfigHelper.getTestPassword());

--- a/test/functional/pages/intolerable.js
+++ b/test/functional/pages/intolerable.js
@@ -14,6 +14,7 @@ function testIntolerable(language = 'en') {
   I.checkOption(IntolerableContnet[language].fields.changes.intolerable.yes);
   I.navByClick(commonContent[language].continue);
 
+  I.waitInUrl(AdulteryFirstFoundOut.path);
   I.seeCurrentUrlEquals(AdulteryFirstFoundOut.path);
 }
 

--- a/test/functional/pages/miniPetition.js
+++ b/test/functional/pages/miniPetition.js
@@ -7,7 +7,7 @@ function testMiniPetitionPage(language = 'en') {
   const I = this;
 
   I.amOnLoadedPage(MiniPetition.path, language);
-  I.waitInUrl(MiniPetition.path, 5);
+  I.waitInUrl(MiniPetition.path);
   I.retry(2).click(MiniPetitionContent[language].fields.changes.hasBeenChanges.no);
   I.waitForText(MiniPetitionContent[language].fields.changes.statementOfTruthNoChanges.yes);
   I.retry(2).click(MiniPetitionContent[language].fields.changes.statementOfTruthNoChanges.yes);

--- a/test/functional/pages/petitionerProgressBar.js
+++ b/test/functional/pages/petitionerProgressBar.js
@@ -4,7 +4,7 @@ const ProgressBarStepContent = require('steps/petition-progress-bar/PetitionProg
 
 function testProgressBar(language = 'en') {
   const I = this;
-  I.waitInUrl(ProgressBarStep.path, 5);
+  I.waitInUrl(ProgressBarStep.path);
   I.amOnLoadedPage(ProgressBarStep.path, language);
   I.see(ProgressBarStepContent[language].title);
 }

--- a/test/functional/pages/respNotAdmitAdutlery.js
+++ b/test/functional/pages/respNotAdmitAdutlery.js
@@ -13,6 +13,7 @@ function testRespNotAdmitAdultery(language = 'en') {
   I.checkOption(RespNotAdmitAdulteryContent[language].fields.amendPetition.no);
   I.navByClick(content[language].continue);
 
+  I.waitInUrl(ApplyForDecreeNisi.path);
   I.seeCurrentUrlEquals(ApplyForDecreeNisi.path);
 }
 

--- a/test/functional/pages/shareCourtDocuments.js
+++ b/test/functional/pages/shareCourtDocuments.js
@@ -16,7 +16,7 @@ function testShareCourtDocumentsPage(option = 'yes', language = 'en') {
   if (option === 'yes') {
     I.seeCurrentUrlEquals(Upload.path);
   } else {
-    I.waitInUrl(CheckYourAnswers.path, 5);
+    I.waitInUrl(CheckYourAnswers.path);
     I.seeCurrentUrlEquals(CheckYourAnswers.path);
   }
 }

--- a/test/functional/pages/upload.js
+++ b/test/functional/pages/upload.js
@@ -3,6 +3,7 @@ const UploadContent = require('steps/upload/Upload.content');
 const commonContent = require('common/content');
 const CheckYourAnswers = require('steps/check-your-answers/CheckYourAnswers.step');
 const ShareCourtDocuments = require('steps/share-court-documents/ShareCourtDocuments.step');
+const config = require('config');
 const ShareCourtDocumentsContent = require(
   'steps/share-court-documents/ShareCourtDocuments.content'
 );
@@ -26,10 +27,16 @@ async function testUploadPage(language = 'en') {
   I.checkOption(ShareCourtDocumentsContent[language].fields.upload.yes);
   I.navByClick(commonContent[language].continue);
 
-  const isDragAndDropSupported = await I.checkElementExist('.dz-hidden-input');
+  if (['safari', 'microsoftEdge'].includes(config.features.browserSupport)) {
+    // eslint-disable-next-line no-console
+    console.log(`Running test in ${config.features.browserSupport}, skipping document upload.`);
+  } else {
+    const isDragAndDropSupported = await I.checkElementExist('.dz-hidden-input');
+    I.uploadFile(isDragAndDropSupported, language);
+    // Below step is broken by bug (raised 30/11/20): https://tools.hmcts.net/jira/browse/RPET-638
+    // I.deleteAFile(language);
+  }
 
-  I.uploadFile(isDragAndDropSupported, language);
-  I.deleteAFile(language);
   I.navByClick(commonContent[language].continue);
 
   I.seeCurrentUrlEquals(CheckYourAnswers.path);

--- a/test/functional/paths/pages.js
+++ b/test/functional/paths/pages.js
@@ -51,7 +51,7 @@ const testAllPages = async(I, language = 'en') => {
 
   I.testCheckYourAnswersPage(language);
 
-  I.testDonePage();
+  await I.testDonePage();
 
   await I.testExitPage();
 

--- a/test/functional/saucelabs.conf.js
+++ b/test/functional/saucelabs.conf.js
@@ -56,7 +56,9 @@ const setupConfig = {
       region: 'eu',
       capabilities: {}
     },
+    SauceLabsBrowserHelper: { require: './helpers/SauceLabsBrowserHelper.js' },
     SauceLabsReportingHelper: { require: './helpers/SauceLabsReportingHelper.js' },
+    ElementExist: { require: './helpers/elementExist.js' },
     JSWait: { require: './helpers/JSWait.js' },
     IdamHelper: { require: './helpers/idamHelper.js' },
     CaseHelper: { require: './helpers/caseHelper.js' },


### PR DESCRIPTION
# Description

Added crossbrowser tests for all browsers, including:
- temporarily turn off `I.deleteAFile()` step due to current bug with the Remove button, where the browser receives a 403 response when it's clicked (https://tools.hmcts.net/jira/browse/RPET-638)
- refactor of `testUploadPage()` to skip uploading documents in Safari and Edge as it's very difficult to do via automation (this is consistent with other Divorce repos)
- config changes including longer timeouts
- refactoring of JSWait in line with other Divorce repos
- browser window re-size for IE11 to improve stability
- removal of hardcoded timeouts to rely on configured timeouts, which allow for longer waits in crossbrowser tests
- additional waits, for stability

