### PR TITLE
DIV-6645: Add content for Served by alternative method

### DIFF
--- a/helpers/petitionHelper.js
+++ b/helpers/petitionHelper.js
@@ -67,7 +67,7 @@ const isServedByAlternativeMethod = caseData => {
     return false;
   }
 
-  return (hasBeenServedByAlternativeMethod(caseData) && !isReceivedAosFromRespondent(caseData));
+  return hasBeenServedByAlternativeMethod(caseData) && !isReceivedAosFromRespondent(caseData);
 };
 const isDeemedServiceApplicationGranted = caseData => {
   return isEqual(toLower(caseData.serviceApplicationGranted), constants.yes) && isEqual(toLower(caseData.serviceApplicationType), constants.deemed);

--- a/helpers/petitionHelper.js
+++ b/helpers/petitionHelper.js
@@ -45,7 +45,7 @@ const isServedByProcessServer = caseData => {
   return isEqual(toLower(servedByProcessServer), constants.yes);
 };
 
-const isReceivedAosFromRespondent = caseData => {
+const hasReceivedAosFromRespondent = caseData => {
   const receivedAosFromResp = getValue(caseData, 'receivedAosFromResp');
   return isEqual(toLower(receivedAosFromResp), constants.yes);
 };
@@ -54,9 +54,19 @@ const isProcessServerService = caseData => {
   if (isPetitionerRepresented(caseData)) {
     return false;
   }
-  return isServedByProcessServer(caseData) && !isReceivedAosFromRespondent(caseData);
+  return isServedByProcessServer(caseData) && !hasReceivedAosFromRespondent(caseData);
 };
 
+const hasBeenServedByAlternativeMethod = caseData => {
+  const servedByAlternativeMethod = getValue(caseData, 'servedByAlternativeMethod');
+  return isEqual(toLower(servedByAlternativeMethod), constants.yes);
+};
+
+const isServedByAlternativeMethod = caseData => {
+  const isServedByAlternativeMethodValid = Boolean(hasBeenServedByAlternativeMethod(caseData) && !isPetitionerRepresented(caseData) && !hasReceivedAosFromRespondent());
+
+  return isServedByAlternativeMethodValid;
+};
 const isDeemedServiceApplicationGranted = caseData => {
   return isEqual(toLower(caseData.serviceApplicationGranted), constants.yes) && isEqual(toLower(caseData.serviceApplicationType), constants.deemed);
 };
@@ -69,15 +79,21 @@ const getProcessServerReason = () => {
   return dnAwaitingTemplate.servedByProcessServer;
 };
 
+const getServedByAlternativeMethodReason = () => {
+  return dnAwaitingTemplate.servedByAlternativeMethod;
+};
+
 module.exports = {
   constants,
   isAwaitingDecreeNisi,
   isAwaitingPronouncementWithHearingDate,
   isProcessServerService,
   isServedByProcessServer,
-  isReceivedAosFromRespondent,
+  isReceivedAosFromRespondent: hasReceivedAosFromRespondent,
   isPetitionerRepresented,
   isDeemedServiceApplicationGranted,
   isDispensedServiceApplicationGranted,
-  getProcessServerReason
+  getProcessServerReason,
+  getServedByAlternativeMethodReason,
+  isServedByAlternativeMethod
 };

--- a/helpers/petitionHelper.js
+++ b/helpers/petitionHelper.js
@@ -45,7 +45,7 @@ const isServedByProcessServer = caseData => {
   return isEqual(toLower(servedByProcessServer), constants.yes);
 };
 
-const hasReceivedAosFromRespondent = caseData => {
+const isReceivedAosFromRespondent = caseData => {
   const receivedAosFromResp = getValue(caseData, 'receivedAosFromResp');
   return isEqual(toLower(receivedAosFromResp), constants.yes);
 };
@@ -54,7 +54,7 @@ const isProcessServerService = caseData => {
   if (isPetitionerRepresented(caseData)) {
     return false;
   }
-  return isServedByProcessServer(caseData) && !hasReceivedAosFromRespondent(caseData);
+  return isServedByProcessServer(caseData) && !isReceivedAosFromRespondent(caseData);
 };
 
 const hasBeenServedByAlternativeMethod = caseData => {
@@ -63,7 +63,7 @@ const hasBeenServedByAlternativeMethod = caseData => {
 };
 
 const isServedByAlternativeMethod = caseData => {
-  const isServedByAlternativeMethodValid = Boolean(hasBeenServedByAlternativeMethod(caseData) && !isPetitionerRepresented(caseData) && !hasReceivedAosFromRespondent(caseData));
+  const isServedByAlternativeMethodValid = Boolean(hasBeenServedByAlternativeMethod(caseData) && !isPetitionerRepresented(caseData) && !isReceivedAosFromRespondent(caseData));
 
   return isServedByAlternativeMethodValid;
 };
@@ -89,7 +89,7 @@ module.exports = {
   isAwaitingPronouncementWithHearingDate,
   isProcessServerService,
   isServedByProcessServer,
-  isReceivedAosFromRespondent: hasReceivedAosFromRespondent,
+  isReceivedAosFromRespondent,
   isPetitionerRepresented,
   isDeemedServiceApplicationGranted,
   isDispensedServiceApplicationGranted,

--- a/helpers/petitionHelper.js
+++ b/helpers/petitionHelper.js
@@ -63,9 +63,11 @@ const hasBeenServedByAlternativeMethod = caseData => {
 };
 
 const isServedByAlternativeMethod = caseData => {
-  const isServedByAlternativeMethodValid = Boolean(hasBeenServedByAlternativeMethod(caseData) && !isPetitionerRepresented(caseData) && !isReceivedAosFromRespondent(caseData));
+  if (isPetitionerRepresented(caseData)) {
+    return false;
+  }
 
-  return isServedByAlternativeMethodValid;
+  return (hasBeenServedByAlternativeMethod(caseData) && !isReceivedAosFromRespondent(caseData));
 };
 const isDeemedServiceApplicationGranted = caseData => {
   return isEqual(toLower(caseData.serviceApplicationGranted), constants.yes) && isEqual(toLower(caseData.serviceApplicationType), constants.deemed);

--- a/helpers/petitionHelper.js
+++ b/helpers/petitionHelper.js
@@ -63,7 +63,7 @@ const hasBeenServedByAlternativeMethod = caseData => {
 };
 
 const isServedByAlternativeMethod = caseData => {
-  const isServedByAlternativeMethodValid = Boolean(hasBeenServedByAlternativeMethod(caseData) && !isPetitionerRepresented(caseData) && !hasReceivedAosFromRespondent());
+  const isServedByAlternativeMethodValid = Boolean(hasBeenServedByAlternativeMethod(caseData) && !isPetitionerRepresented(caseData) && !hasReceivedAosFromRespondent(caseData));
 
   return isServedByAlternativeMethodValid;
 };

--- a/mocks/steps/modify-session/ModifySession.content.json
+++ b/mocks/steps/modify-session/ModifySession.content.json
@@ -41,6 +41,11 @@
           "yes": "Yes",
           "no": "No"
         },
+        "servedByAlternativeMethod": {
+          "title": "Served by alternative method",
+          "yes": "Yes",
+          "no": "No"
+        },
         "reasonForDivorceBehaviourDetails": {
           "title": "Specify the unreasonable behaviour details"
         },

--- a/mocks/steps/modify-session/ModifySession.step.js
+++ b/mocks/steps/modify-session/ModifySession.step.js
@@ -77,6 +77,7 @@ class ModifySession extends Question {
     const serviceApplicationType = text;
 
     const servedByProcessServer = text;
+    const servedByAlternativeMethod = text;
     const receivedAosFromResp = text;
 
     return form({
@@ -110,6 +111,7 @@ class ModifySession extends Question {
       serviceApplicationGranted,
       serviceApplicationType,
       servedByProcessServer,
+      servedByAlternativeMethod,
       receivedAosFromResp
     });
   }

--- a/mocks/steps/modify-session/sections/petitioner.html
+++ b/mocks/steps/modify-session/sections/petitioner.html
@@ -66,6 +66,15 @@
     hideQuestion = false,
     inline = true
   ) }}
+
+{{ selectionButtons(fields.servedByAlternativeMethod, content.fields.petitioner.servedByAlternativeMethod.title,
+  options = [
+    { label: content.fields.petitioner.servedByAlternativeMethod.yes, value: "Yes" },
+    { label: content.fields.petitioner.servedByAlternativeMethod.no, value: "No" }
+  ],
+  hideQuestion = false,
+  inline = true
+  ) }}
 {% endcall %}
 
 <div class="js-hidden" id="reason-adultery-container">

--- a/steps/petition-progress-bar/PetitionProgressBar.step.js
+++ b/steps/petition-progress-bar/PetitionProgressBar.step.js
@@ -14,7 +14,9 @@ const {
   isAwaitingDecreeNisi,
   isProcessServerService,
   isAwaitingPronouncementWithHearingDate,
-  getProcessServerReason
+  getProcessServerReason,
+  getServedByAlternativeMethodReason,
+  isServedByAlternativeMethod
 } = require('helpers/petitionHelper');
 const i18next = require('i18next');
 const commonContent = require('common/content');
@@ -160,6 +162,10 @@ class PetitionProgressBar extends Interstitial {
 
     if (isProcessServerService(this.case)) {
       return getProcessServerReason();
+    }
+
+    if (isServedByAlternativeMethod(this.case)) {
+      return getServedByAlternativeMethodReason();
     }
 
     return this.case.permittedDecreeNisiReason ? this.case.permittedDecreeNisiReason : constants.undefendedReason;

--- a/steps/petition-progress-bar/petitionerStateTemplates.js
+++ b/steps/petition-progress-bar/petitionerStateTemplates.js
@@ -82,13 +82,15 @@ const permitDNReasonMap = new Map([
   ['4', './sections/defendedWithoutAnswer/PetitionProgressBar.defendedWithoutAnswer.template.html'],
   ['5', './sections/deemedApproved/PetitionProgressBar.deemedApproved.template.html'],
   ['6', './sections/dispensedApproved/PetitionProgressBar.dispensedApproved.template.html'],
-  ['7', './sections/processServerService/PetitionProgressBar.processServerService.template.html']
+  ['7', './sections/processServerService/PetitionProgressBar.processServerService.template.html'],
+  ['8', './sections/servedByAlternativeMethod/PetitionProgressBar.servedByAlternativeMethod.template.html']
 ]);
 
 const dnAwaitingTemplate = {
   deemed: '5',
   dispensed: '6',
-  servedByProcessServer: '7'
+  servedByProcessServer: '7',
+  servedByAlternativeMethod: '8'
 };
 
 module.exports = {

--- a/steps/petition-progress-bar/sections/servedByAlternativeMethod/PetitionProgressBar.content.servedByAlternativeMethod.json
+++ b/steps/petition-progress-bar/sections/servedByAlternativeMethod/PetitionProgressBar.content.servedByAlternativeMethod.json
@@ -5,8 +5,8 @@
     "servedByAlternativeMethodAosOverdue": "Because it is more than 7 days since confirmation of service, you are now able continue to the next stage and apply for a decree nisi."
   },
   "cy": {
-    "servedByAlternativeMethodStatusMsg": "Your divorce petition has been served by an alternative method",
-    "servedByAlternativeMethod": "Your {{ divorceWho }} was served by an alternative method. However, they have not yet responded.",
-    "servedByAlternativeMethodAosOverdue": "Because it is more than 7 days since confirmation of service, you are now able continue to the next stage and apply for a decree nisi."
+    "servedByAlternativeMethodStatusMsg": "[CY] Your divorce petition has been served by an alternative method",
+    "servedByAlternativeMethod": "[CY] Your {{ divorceWho }} was served by an alternative method. However, they have not yet responded.",
+    "servedByAlternativeMethodAosOverdue": "[CY] Because it is more than 7 days since confirmation of service, you are now able continue to the next stage and apply for a decree nisi."
   }
 }

--- a/steps/petition-progress-bar/sections/servedByAlternativeMethod/PetitionProgressBar.content.servedByAlternativeMethod.json
+++ b/steps/petition-progress-bar/sections/servedByAlternativeMethod/PetitionProgressBar.content.servedByAlternativeMethod.json
@@ -1,0 +1,12 @@
+{
+  "en": {
+    "servedByAlternativeMethodStatusMsg": "Your divorce petition has been served by an alternative method",
+    "servedByAlternativeMethod": "Your {{ divorceWho }} was served by an alternative method. However, they have not yet responded.",
+    "servedByAlternativeMethodAosOverdue": "Because it is more than 7 days since confirmation of service, you are now able continue to the next stage and apply for a decree nisi."
+  },
+  "cy": {
+    "servedByAlternativeMethodStatusMsg": "Your divorce petition has been served by an alternative method",
+    "servedByAlternativeMethod": "Your {{ divorceWho }} was served by an alternative method. However, they have not yet responded.",
+    "servedByAlternativeMethodAosOverdue": "Because it is more than 7 days since confirmation of service, you are now able continue to the next stage and apply for a decree nisi."
+  }
+}

--- a/steps/petition-progress-bar/sections/servedByAlternativeMethod/PetitionProgressBar.servedByAlternativeMethod.template.html
+++ b/steps/petition-progress-bar/sections/servedByAlternativeMethod/PetitionProgressBar.servedByAlternativeMethod.template.html
@@ -1,0 +1,31 @@
+{% from "look-and-feel/components/progress-list.njk" import progressList %}
+
+{{
+  progressList({
+    one: {
+      label: content.youApply,
+      complete: true
+    },
+    two: {
+      label: content.husbandWifeMustRespond,
+      complete: true
+    },
+    three: {
+      label: content.getDecreeNisi,
+      current: true
+    },
+    four: {
+      label: content.madeFinal
+    }
+  })
+}}
+
+<h2 class="govuk-heading-m">{{ content.servedByAlternativeMethodStatusMsg }}</h2>
+
+<p class="govuk-body">{{ content.servedByAlternativeMethod }}</p>
+
+<p class="govuk-body">{{ content.servedByAlternativeMethodAosOverdue }}</p>
+
+<form action="{{ postUrl | default(path if path else url) }}" method="post" class="form">
+  <input role="button" draggable="false" class="govuk-button govuk-button--start" type="submit" value="{{ content.continue }}">
+</form>

--- a/steps/petition-progress-bar/sections/undefended/PetitionProgressBar.undefended.template.html
+++ b/steps/petition-progress-bar/sections/undefended/PetitionProgressBar.undefended.template.html
@@ -20,22 +20,21 @@
   })
 }}
 
-<h2 class="govuk-heading-m">{{ content.undefendedAppStatusMsg }}</h2>
-
-{% if respNotAdmitsToFact %}
-  {% if isCaseAmended %}
-    <p class="govuk-body">{{ content.undefendedAmendedCaseButNotAdmit }}</p>
+  <h2 class="govuk-heading-m">{{ content.undefendedAppStatusMsg }}</h2>
+  {% if respNotAdmitsToFact %}
+    {% if isCaseAmended %}
+      <p class="govuk-body">{{ content.undefendedAmendedCaseButNotAdmit }}</p>
+    {% else %}
+      <p class="govuk-body">{{ content.undefendedButNotAdmit }}</p>
+    {% endif %}
   {% else %}
-    <p class="govuk-body">{{ content.undefendedButNotAdmit }}</p>
+    {% if isCaseAmended %}
+      <p class="govuk-body">{{ content.undefendedAmendedAppStatusMsgDetails1 }}</p>
+    {% else %}
+      <p class="govuk-body">{{ content.undefendedAppStatusMsgDetails1 }}</p>
+    {% endif %}
   {% endif %}
-{% else %}
-  {% if isCaseAmended %}
-    <p class="govuk-body">{{ content.undefendedAmendedAppStatusMsgDetails1 }}</p>
-  {% else %}
-    <p class="govuk-body">{{ content.undefendedAppStatusMsgDetails1 }}</p>
-  {% endif %}
-{% endif %}
-<p class="govuk-body">{{ content.undefendedAppStatusMsgDetails2 }}</p>
+  <p class="govuk-body">{{ content.undefendedAppStatusMsgDetails2 }}</p>
 
 <details class="govuk-details">
   <summary class="govuk-details__summary" aria-controls="details-content-0" aria-expanded="false">

--- a/steps/petition-progress-bar/sections/undefended/PetitionProgressBar.undefended.template.html
+++ b/steps/petition-progress-bar/sections/undefended/PetitionProgressBar.undefended.template.html
@@ -19,7 +19,6 @@
     }
   })
 }}
-
 <h2 class="govuk-heading-m">{{ content.undefendedAppStatusMsg }}</h2>
 
 {% if respNotAdmitsToFact %}

--- a/steps/petition-progress-bar/sections/undefended/PetitionProgressBar.undefended.template.html
+++ b/steps/petition-progress-bar/sections/undefended/PetitionProgressBar.undefended.template.html
@@ -1,40 +1,41 @@
 {% from "look-and-feel/components/progress-list.njk" import progressList %}
 
 {{
-  progressList({
-    one: {
-      label: content.youApply,
-      complete: true
-    },
-    two: {
-      label: content.husbandWifeMustRespond,
-      complete: true
-    },
-    three: {
-      label: content.getDecreeNisi,
-      current: true
-    },
-    four: {
-      label: content.madeFinal
-    }
-  })
+progressList({
+one: {
+label: content.youApply,
+complete: true
+},
+two: {
+label: content.husbandWifeMustRespond,
+complete: true
+},
+three: {
+label: content.getDecreeNisi,
+current: true
+},
+four: {
+label: content.madeFinal
+}
+})
 }}
 
-  <h2 class="govuk-heading-m">{{ content.undefendedAppStatusMsg }}</h2>
-  {% if respNotAdmitsToFact %}
-    {% if isCaseAmended %}
-      <p class="govuk-body">{{ content.undefendedAmendedCaseButNotAdmit }}</p>
-    {% else %}
-      <p class="govuk-body">{{ content.undefendedButNotAdmit }}</p>
-    {% endif %}
+<h2 class="govuk-heading-m">{{ content.undefendedAppStatusMsg }}</h2>
+
+{% if respNotAdmitsToFact %}
+  {% if isCaseAmended %}
+    <p class="govuk-body">{{ content.undefendedAmendedCaseButNotAdmit }}</p>
   {% else %}
-    {% if isCaseAmended %}
-      <p class="govuk-body">{{ content.undefendedAmendedAppStatusMsgDetails1 }}</p>
-    {% else %}
-      <p class="govuk-body">{{ content.undefendedAppStatusMsgDetails1 }}</p>
-    {% endif %}
+    <p class="govuk-body">{{ content.undefendedButNotAdmit }}</p>
   {% endif %}
-  <p class="govuk-body">{{ content.undefendedAppStatusMsgDetails2 }}</p>
+{% else %}
+  {% if isCaseAmended %}
+    <p class="govuk-body">{{ content.undefendedAmendedAppStatusMsgDetails1 }}</p>
+  {% else %}
+    <p class="govuk-body">{{ content.undefendedAppStatusMsgDetails1 }}</p>
+  {% endif %}
+{% endif %}
+<p class="govuk-body">{{ content.undefendedAppStatusMsgDetails2 }}</p>
 
 <details class="govuk-details">
   <summary class="govuk-details__summary" aria-controls="details-content-0" aria-expanded="false">

--- a/steps/petition-progress-bar/sections/undefended/PetitionProgressBar.undefended.template.html
+++ b/steps/petition-progress-bar/sections/undefended/PetitionProgressBar.undefended.template.html
@@ -1,23 +1,23 @@
 {% from "look-and-feel/components/progress-list.njk" import progressList %}
 
 {{
-progressList({
-one: {
-label: content.youApply,
-complete: true
-},
-two: {
-label: content.husbandWifeMustRespond,
-complete: true
-},
-three: {
-label: content.getDecreeNisi,
-current: true
-},
-four: {
-label: content.madeFinal
-}
-})
+  progressList({
+    one: {
+      label: content.youApply,
+      complete: true
+    },
+    two: {
+      label: content.husbandWifeMustRespond,
+      complete: true
+    },
+    three: {
+      label: content.getDecreeNisi,
+      current: true
+    },
+    four: {
+      label: content.madeFinal
+    }
+  })
 }}
 
 <h2 class="govuk-heading-m">{{ content.undefendedAppStatusMsg }}</h2>

--- a/test/unit/helpers/petitionHelper.test.js
+++ b/test/unit/helpers/petitionHelper.test.js
@@ -156,6 +156,11 @@ describe(modulePath, () => {
         expect(isServedByAlternativeMethod('AnotherState')).to.equal(false);
       });
 
+      it('should return false if petitioner is represented', () => {
+        session.case.data.petitionerSolicitorEmail = 'solicitorEmail@mail.com';
+        expect(isServedByAlternativeMethod('AnotherState')).to.equal(false);
+      });
+
       it('should return false if not served by alternative method', () => {
         session.case.data.servedByAlternativeMethod = 'No';
 

--- a/test/unit/helpers/petitionHelper.test.js
+++ b/test/unit/helpers/petitionHelper.test.js
@@ -128,7 +128,7 @@ describe(modulePath, () => {
           data: {
             servedByAlternativeMethod: 'Yes',
             receivedAosFromResp: 'No',
-            permittedDecreeNisiReason: '0'
+            permittedDecreeNisiReason: '8'
           }
         }
       };
@@ -138,6 +138,13 @@ describe(modulePath, () => {
       it('should return true if all conditions are valid', () => {
         session.case.data.servedByAlternativeMethod = 'Yes';
         session.case.data.petitionerSolicitorEmail = null;
+        session.case.data.receivedAosFromResp = 'something';
+
+        expect(isServedByAlternativeMethod(session.case.data)).to.equal(true);
+      });
+
+      it('AC2: Served by alternative method and AOS received within 7 days', () => {
+        session.case.data.servedByAlternativeMethod = 'Yes';
         session.case.data.receivedAosFromResp = 'something';
 
         expect(isServedByAlternativeMethod(session.case.data)).to.equal(true);

--- a/test/unit/helpers/petitionHelper.test.js
+++ b/test/unit/helpers/petitionHelper.test.js
@@ -143,7 +143,7 @@ describe(modulePath, () => {
         expect(isServedByAlternativeMethod(session.case.data)).to.equal(true);
       });
 
-      it('AC2: Served by alternative method and AOS received within 7 days', () => {
+      it('should return true when served by alt method and AOS received within 7 days', () => {
         session.case.data.servedByAlternativeMethod = 'Yes';
         session.case.data.receivedAosFromResp = 'something';
 

--- a/test/unit/helpers/petitionHelper.test.js
+++ b/test/unit/helpers/petitionHelper.test.js
@@ -158,7 +158,7 @@ describe(modulePath, () => {
 
       it('should return false if petitioner is represented', () => {
         session.case.data.petitionerSolicitorEmail = 'solicitorEmail@mail.com';
-        expect(isServedByAlternativeMethod('AnotherState')).to.equal(false);
+        expect(isServedByAlternativeMethod(session)).to.equal(false);
       });
 
       it('should return false if not served by alternative method', () => {

--- a/test/unit/helpers/petitionHelper.test.js
+++ b/test/unit/helpers/petitionHelper.test.js
@@ -12,7 +12,8 @@ const {
   isPetitionerRepresented,
   getProcessServerReason,
   isDeemedServiceApplicationGranted,
-  isDispensedServiceApplicationGranted
+  isDispensedServiceApplicationGranted,
+  isServedByAlternativeMethod
 } = require('helpers/petitionHelper');
 
 describe(modulePath, () => {
@@ -117,5 +118,54 @@ describe(modulePath, () => {
     newSession.case.data.serviceApplicationType = constants.dispensed;
 
     expect(isDispensedServiceApplicationGranted(newSession.case.data)).to.equal(true);
+  });
+
+  describe('Served by alternative method: ', () => {
+    beforeEach(() => {
+      session = {
+        case: {
+          state: 'AwaitingDecreeNisi',
+          data: {
+            servedByAlternativeMethod: 'Yes',
+            receivedAosFromResp: 'No',
+            permittedDecreeNisiReason: '0'
+          }
+        }
+      };
+    });
+
+    describe('Valid Scenario', () => {
+      it('should return true if all conditions are valid', () => {
+        session.case.data.servedByAlternativeMethod = 'Yes';
+        session.case.data.petitionerSolicitorEmail = null;
+        session.case.data.receivedAosFromResp = 'something';
+
+        expect(isServedByAlternativeMethod(session.case.data)).to.equal(true);
+      });
+    });
+
+    describe('Invalid scenario', () => {
+      it('should return false if not in AwaitingDecreeNisi state', () => {
+        expect(isServedByAlternativeMethod('AnotherState')).to.equal(false);
+      });
+
+      it('should return false if not served by alternative method', () => {
+        session.case.data.servedByAlternativeMethod = 'No';
+
+        expect(isServedByAlternativeMethod(session.case)).to.equal(false);
+      });
+
+      it('should return false if petitioner is represented by a solicitor', () => {
+        session.case.data.petitionerSolicitorEmail = 'petsolicitor@mail.com';
+
+        expect(isServedByAlternativeMethod(session.case)).to.equal(false);
+      });
+
+      it('should return false if AoS has been received from respondent', () => {
+        session.case.data.receivedAosFromResp = 'Yes';
+
+        expect(isServedByAlternativeMethod(session.case)).to.equal(false);
+      });
+    });
   });
 });

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -57,7 +57,9 @@ const templates = {
   dispensedApproved:
     './sections/dispensedApproved/PetitionProgressBar.dispensedApproved.template.html',
   processServerService:
-    './sections/processServerService/PetitionProgressBar.processServerService.template.html'
+    './sections/processServerService/PetitionProgressBar.processServerService.template.html',
+  servedByAlternativeMethod:
+    './sections/servedByAlternativeMethod/PetitionProgressBar.servedByAlternativeMethod.template.html'
 };
 
 // get all content for all pages
@@ -262,7 +264,6 @@ describe(modulePath, () => {
       const specificContent = ['undefendedAmendedAppStatusMsgDetails1'];
       return content(PetitionProgressBar, yesAdmitSession, { specificContent });
     });
-
 
     it('renders undefendedAppStatusMsgDetails1: behaviour case ', () => {
       const behaviourSession = {
@@ -522,6 +523,37 @@ describe(modulePath, () => {
       });
     });
   });
+
+  describe('CCD state: AwaitingDecreeNisi. Testing servedByAlternativeMethod', () => {
+    let session = {};
+    let petitionProgressBar = {};
+
+    before(() => {
+      session = {
+        case: {
+          state: 'AwaitingDecreeNisi',
+          data: {
+            servedByAlternativeMethod: 'Yes',
+            receivedAosFromResp: 'No',
+            permittedDecreeNisiReason: '8'
+          }
+        }
+      };
+      petitionProgressBar = stepAsInstance(PetitionProgressBar, session);
+    });
+
+    describe('Content Rendering for Served By Alternative Method', () => {
+      it('should render the servedByAlternativeMethod template', () => {
+        expect(petitionProgressBar.stateTemplate).to.equal(templates.servedByAlternativeMethod);
+      });
+
+      it('should render the correct content', () => {
+        const specificContent = Object.keys(pageContent.servedByAlternativeMethod);
+        return content(PetitionProgressBar, session, { specificContent });
+      });
+    });
+  });
+
 
   describe('CCD state: AosSubmittedAwaitingAnswer', () => {
     const session = {

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -525,10 +525,6 @@ describe(modulePath, () => {
     });
   });
 
-  /*
-  here
-   */
-
   describe('CCD state: AwaitingDecreeNisi. ServedByAlternativeMethod', () => {
     let session = {};
     let petitionProgressBar = {};

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -554,7 +554,6 @@ describe(modulePath, () => {
     });
   });
 
-
   describe('CCD state: AosSubmittedAwaitingAnswer', () => {
     const session = {
       case: {

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -57,7 +57,9 @@ const templates = {
   dispensedApproved:
     './sections/dispensedApproved/PetitionProgressBar.dispensedApproved.template.html',
   processServerService:
-    './sections/processServerService/PetitionProgressBar.processServerService.template.html'
+    './sections/processServerService/PetitionProgressBar.processServerService.template.html',
+  servedByAlternativeMethod:
+    './sections/servedByAlternativeMethod/PetitionProgressBar.servedByAlternativeMethod.template.html'
 };
 
 // get all content for all pages
@@ -539,7 +541,7 @@ describe(modulePath, () => {
             data: {
               servedByAlternativeMethod: 'Yes',
               receivedAosFromResp: 'No',
-              permittedDecreeNisiReason: '8'
+              permittedDecreeNisiReason: '4'
             }
           }
         };

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -57,9 +57,7 @@ const templates = {
   dispensedApproved:
     './sections/dispensedApproved/PetitionProgressBar.dispensedApproved.template.html',
   processServerService:
-    './sections/processServerService/PetitionProgressBar.processServerService.template.html',
-  servedByAlternativeMethod:
-    './sections/servedByAlternativeMethod/PetitionProgressBar.servedByAlternativeMethod.template.html'
+    './sections/processServerService/PetitionProgressBar.processServerService.template.html'
 };
 
 // get all content for all pages
@@ -264,6 +262,7 @@ describe(modulePath, () => {
       const specificContent = ['undefendedAmendedAppStatusMsgDetails1'];
       return content(PetitionProgressBar, yesAdmitSession, { specificContent });
     });
+
 
     it('renders undefendedAppStatusMsgDetails1: behaviour case ', () => {
       const behaviourSession = {
@@ -524,25 +523,29 @@ describe(modulePath, () => {
     });
   });
 
-  describe('CCD state: AwaitingDecreeNisi. Testing servedByAlternativeMethod', () => {
+  /*
+  here
+   */
+
+  describe('CCD state: AwaitingDecreeNisi. ServedByAlternativeMethod', () => {
     let session = {};
     let petitionProgressBar = {};
 
-    before(() => {
-      session = {
-        case: {
-          state: 'AwaitingDecreeNisi',
-          data: {
-            servedByAlternativeMethod: 'Yes',
-            receivedAosFromResp: 'No',
-            permittedDecreeNisiReason: '8'
-          }
-        }
-      };
-      petitionProgressBar = stepAsInstance(PetitionProgressBar, session);
-    });
-
     describe('Content Rendering for Served By Alternative Method', () => {
+      before(() => {
+        session = {
+          case: {
+            state: 'AwaitingDecreeNisi',
+            data: {
+              servedByAlternativeMethod: 'Yes',
+              receivedAosFromResp: 'No',
+              permittedDecreeNisiReason: '8'
+            }
+          }
+        };
+        petitionProgressBar = stepAsInstance(PetitionProgressBar, session);
+      });
+
       it('should render the servedByAlternativeMethod template', () => {
         expect(petitionProgressBar.stateTemplate).to.equal(templates.servedByAlternativeMethod);
       });
@@ -553,6 +556,7 @@ describe(modulePath, () => {
       });
     });
   });
+
 
   describe('CCD state: AosSubmittedAwaitingAnswer', () => {
     const session = {


### PR DESCRIPTION
### Ticket ###
https://tools.hmcts.net/jira/browse/DIV-6645


### Common Lib PR ###
https://github.com/hmcts/div-common-lib/pull/44

Alignment:
COS: https://github.com/hmcts/div-case-orchestration-service/pull/1164
CFS: 
CMS: https://github.com/hmcts/div-case-maintenance-service/pull/379




# Description

As a Petitioner
When I have been emailed to tell me that it has been over 7 days since alternative service method
When I login I should be taken to a DN landing page with conditional info.

AC1 - DN landing page for alternative service method
**GIVEN** the case is in the state is ID:'AwaitingDecreeNisi'
**AND** the case has had alternative method confirmed (field ID: 'ServedByAlternativeMethod' = 'Yes')
**AND** the AOS has not been submitted by the respondent (how do we identify?)
**AND** is citizen case (petitioner not represented)
**WHEN** petitioner logs into PFE
**THEN** they are redirected with the 'DN landing page - alternative method' on DN with the following conditional content:
