### PR TITLE
DIV-5462: Quick fix: Remove mapping of new landing page for AOS overdue

### DIFF
--- a/steps/petition-progress-bar/petitionerStateTemplates.js
+++ b/steps/petition-progress-bar/petitionerStateTemplates.js
@@ -53,12 +53,9 @@ const addStateMappingsForServedByBailiffSuccessful = map => {
   const aosAwaitingTemplate = map[1];
   aosAwaitingTemplate.state = removeStateMappingFor(aosAwaitingTemplate, 'aosawaiting');
 
-  const aosOverdueTemplate = map[5];
-  aosOverdueTemplate.state = removeStateMappingFor(aosOverdueTemplate, 'aosoverdue');
-
   const newAosTemplate = {
     template: './sections/bailiffServiceSuccessful/PetitionProgressBar.bailiffServiceSuccessful.template.html',
-    state: ['aosawaiting', 'aosoverdue']
+    state: ['aosawaiting']
   };
   map.push(newAosTemplate);
 };

--- a/test/unit/steps/petitionerProgressBar.test.js
+++ b/test/unit/steps/petitionerProgressBar.test.js
@@ -736,15 +736,6 @@ describe(modulePath, () => {
 
       return content(PetitionProgressBar, session, { specificContent, specificContentToNotExist });
     });
-
-    it('renders the correct content for successfulServedByBailiff is Yes', () => {
-      session.case.data = { successfulServedByBailiff: 'yes' };
-      const specificContent = Object.keys(pageContent.bailiffServiceSuccessful);
-      const specificContentToNotExist = contentToNotExist('bailiffServiceSuccessful');
-
-      return content(PetitionProgressBar, session, { specificContent, specificContentToNotExist });
-    });
-
     it('renders the correct template for successfulServedByBailiff is No', () => {
       session.case.data = { successfulServedByBailiff: 'no' };
       const instance = stepAsInstance(PetitionProgressBar, session);
@@ -755,12 +746,6 @@ describe(modulePath, () => {
       session.case.data = { successfulServedByBailiff: '' };
       const instance = stepAsInstance(PetitionProgressBar, session);
       expect(instance.stateTemplate).to.eql(templates.respondentNotReplied);
-    });
-
-    it('renders the correct template for successfulServedByBailiff is Yes', () => {
-      session.case.data = { successfulServedByBailiff: 'yes' };
-      const instance = stepAsInstance(PetitionProgressBar, session);
-      expect(instance.stateTemplate).to.eql(templates.bailiffServiceSuccessful);
     });
   });
 


### PR DESCRIPTION
# Description

Going to the new Bailiff landing page should only be for when the state is AOS awaiting. AOS overdue should not be included.

Fixes https://tools.hmcts.net/jira/browse/DIV-5462

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

Unit tests


**Test Configuration**:

* Hardware:
* O/S and version:
* JDK:

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [x] My changes generate no new warnings
- [x] I have added tests that prove my fix is effective or that my feature works
- [x] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
